### PR TITLE
Implement dispose pattern to allow for derived XlsxWriter

### DIFF
--- a/src/LargeXlsx/XlsxWriter.cs
+++ b/src/LargeXlsx/XlsxWriter.cs
@@ -44,6 +44,7 @@ namespace LargeXlsx
         private readonly Stylesheet _stylesheet;
         private Worksheet _currentWorksheet;
         private bool _hasFormulasWithoutResult;
+        private bool _disposed;
 
         public XlsxStyle DefaultStyle { get; private set; }
         public int CurrentRowNumber => _currentWorksheet.CurrentRowNumber;
@@ -63,10 +64,28 @@ namespace LargeXlsx
 
         public void Dispose()
         {
-            _currentWorksheet?.Dispose();
-            _stylesheet.Save(_zipWriter);
-            Save();
-            _zipWriter.Dispose();
+            Dispose(true);
+            GC.SuppressFinalize(this); // just in case we add a finalizer later.
+        }
+
+        public bool IsDisposed => _disposed;
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                _currentWorksheet?.Dispose();
+                _stylesheet.Save(_zipWriter);
+                Save();
+                _zipWriter.Dispose();
+            }
+
+            _disposed = true;
         }
 
         private void Save()

--- a/src/LargeXlsx/XlsxWriter.cs
+++ b/src/LargeXlsx/XlsxWriter.cs
@@ -83,6 +83,7 @@ namespace LargeXlsx
             {
                 _currentWorksheet?.Dispose();
                 _stylesheet.Save(_zipWriter);
+                _sharedStringTable.Save(_zipWriter);
                 Save();
                 _zipWriter.Dispose();
             }

--- a/tests/LargeXlsx.Tests/DisposeTest.cs
+++ b/tests/LargeXlsx.Tests/DisposeTest.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using FluentAssertions;
+using NUnit.Framework;
+using SharpCompress.Compressors.Deflate;
+
+namespace LargeXlsx.Tests;
+
+[TestFixture]
+public static class DisposeTest
+{
+    [Test]
+    public static void DisposeWriterTwice()
+    {
+        using var stream = new MemoryStream();
+
+        var xlsxWriter = new XlsxWriter(stream);
+        xlsxWriter.BeginWorksheet("Sheet 1").BeginRow().Write("Hello World!");
+        xlsxWriter.Dispose();
+
+        // dispose a 2nd time (should be idempotent)
+        Assert.DoesNotThrow(() => xlsxWriter.Dispose());
+    }
+
+    [Test]
+    public static void CanDeriveFromWriterSafely()
+    {
+        using var stream = new MemoryStream();
+
+        var myWriter = new MyWriter(stream);
+        myWriter.BeginWorksheet("Sheet 1").BeginRow().Write("Hello World!");
+        myWriter.Dispose();
+
+        Assert.True(myWriter.IsMyWriterDisposed);
+        Assert.True(myWriter.IsDisposed); // base is disposed too
+    }
+
+    [Test]
+    public static void FinalizerCleansBase()
+    {
+        WeakReference? weak = null;
+
+        // track with WeakReference
+        var action = new Action(() =>
+        {
+            using var stream = new MemoryStream();
+            var myWriter = new MyWriter(stream);
+            myWriter.BeginWorksheet("Sheet 1").BeginRow().Write("Hello World!");
+            myWriter.IsMyWriterDisposed.Should().Be(false);
+            weak = new WeakReference(myWriter, true); // true = Track reference _after_ Finalize()
+        });
+
+        action();
+
+        GC.Collect(0, GCCollectionMode.Forced);
+        GC.WaitForPendingFinalizers();
+
+        // finalizers call dispose
+
+        ((MyWriter?)weak!.Target)?.IsMyWriterDisposed.Should().Be(true);
+        ((MyWriter?)weak!.Target)?.IsDisposed.Should().Be(true);
+    }
+
+    class MyWriter : XlsxWriter
+    {
+        private bool _disposed;
+
+        // sample unmanaged object
+        private readonly IntPtr _unmanagedPointer;
+
+        // sample managed object
+        private readonly MemoryStream _memoryStream;
+
+        public MyWriter(Stream stream, CompressionLevel compressionLevel = CompressionLevel.Level3, bool useZip64 = false) 
+            : base(stream, compressionLevel, useZip64)
+        {
+            _unmanagedPointer = Marshal.AllocHGlobal(1024);
+            _memoryStream = new MemoryStream();
+        }
+
+        public bool IsMyWriterDisposed => _disposed;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                _memoryStream.Dispose();
+            }
+
+            Marshal.FreeHGlobal(_unmanagedPointer);
+            _disposed = true;
+
+            base.Dispose(disposing);
+        }
+
+        ~MyWriter()
+        {
+            Dispose(false);
+        }
+    }
+}


### PR DESCRIPTION
Added the protected Dispose method to allow for a derived XlsxWriter to clean up the base XlsxWriter. Also added _disposed flag to make disposal idempotent.