### PR TITLE
Remove string interpolation for perf

### DIFF
--- a/src/LargeXlsx/Worksheet.cs
+++ b/src/LargeXlsx/Worksheet.cs
@@ -145,8 +145,27 @@ namespace LargeXlsx
         public void Write(double value, XlsxStyle style)
         {
             EnsureRow();
-            _streamWriter.WriteLine("<c r=\"{0}{1}\" s=\"{2}\"><v>{3}</v></c>",
-                Util.GetColumnName(CurrentColumnNumber), CurrentRowNumber, _stylesheet.ResolveStyleId(style), value);
+
+            _streamWriter.Write("<c r=\"");
+            _streamWriter.Write(Util.GetColumnName(CurrentColumnNumber));
+            _streamWriter.Write(CurrentRowNumber);
+            _streamWriter.Write("\" s=\"");
+            _streamWriter.Write(_stylesheet.ResolveStyleId(style));
+            _streamWriter.Write("\"><v>");
+            _streamWriter.Write(value);
+            _streamWriter.WriteLine("</v></c>");
+
+            // the following commented-out code is more intuitive than that above, but the
+            // additional string allocations put pressure on the small object heap because
+            // the code is in a hot path (at least in the Zip64Huge examples which write
+            // numbers to the cells).
+            //
+            //_streamWriter.WriteLine("<c r=\"{0}{1}\" s=\"{2}\"><v>{3}</v></c>",
+            //    Util.GetColumnName(CurrentColumnNumber),
+            //    CurrentRowNumber,
+            //    _stylesheet.ResolveStyleId(style),
+            //    value);
+
             CurrentColumnNumber++;
         }
 


### PR DESCRIPTION
This small change makes some perf improvements (and reduces memory use) in the examples by removing string interpolation on a hot path (writing numbers to cells). If the PR is accepted, the modification could be extended to the other Write methods in Worksheet.cs and perhaps some common functionality could be extracted.

@salvois Note that code readability suffers a little, so you'd want to be sure the performance gain is worth it.