### PR TITLE
Fix ContentType for extension

### DIFF
--- a/src/LargeXlsx/XlsxWriter.cs
+++ b/src/LargeXlsx/XlsxWriter.cs
@@ -109,7 +109,7 @@ namespace LargeXlsx
                     worksheetTags.Append($"<Override PartName=\"/xl/worksheets/sheet{worksheet.Id}.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml\"/>");
                 streamWriter.Write("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
                                    + "<Types xmlns=\"http://schemas.openxmlformats.org/package/2006/content-types\">"
-                                   + "<Default Extension=\"xml\" ContentType=\"xml\"/>"
+                                   + "<Default Extension=\"xml\" ContentType=\"application/xml\"/>"
                                    + "<Default Extension=\"rels\" ContentType=\"application/vnd.openxmlformats-package.relationships+xml\"/>"
                                    + "<Override PartName=\"/_rels/.rels\" ContentType=\"application/vnd.openxmlformats-package.relationships+xml\"/>"
                                    + "<Override PartName=\"/xl/workbook.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\"/>"


### PR DESCRIPTION
Hello @salvois, 

Firstly thank you for the amazing library. 

During migration from 1.6.3 to 1.7.2 I noticed a bug in the code that lead that tools like PowerBI cannot read the file. 

This PR fix it. 