### PR TITLE
Fix culture problem in stylesheet

### DIFF
--- a/examples/Examples/StyledLargeCreateStyles.cs
+++ b/examples/Examples/StyledLargeCreateStyles.cs
@@ -54,7 +54,7 @@ public static class StyledLargeCreateStyles
         using var xlsxWriter = new XlsxWriter(stream);
         var colors = Enumerable.Repeat(0, 100).Select(_ => Color.FromArgb(rnd.Next(256), rnd.Next(256), rnd.Next(256))).ToList();
         var headerStyle = new XlsxStyle(
-            new XlsxFont("Calibri", 11, Color.White, bold: true),
+            new XlsxFont("Calibri", 10.5, Color.White, bold: true),
             new XlsxFill(Color.FromArgb(0, 0x45, 0x86)),
             XlsxBorder.None,
             XlsxNumberFormat.General,

--- a/src/LargeXlsx/Stylesheet.cs
+++ b/src/LargeXlsx/Stylesheet.cs
@@ -112,7 +112,7 @@ namespace LargeXlsx
         public void Save(ZipWriter zipWriter)
         {
             using (var stream = zipWriter.WriteToStream("xl/styles.xml", new ZipWriterEntryOptions()))
-            using (var streamWriter = new StreamWriter(stream, Encoding.UTF8))
+            using (var streamWriter = new InvariantCultureStreamWriter(stream))
             {
                 streamWriter.WriteLine("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
                                    + "<styleSheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\">");


### PR DESCRIPTION
Hey, 

I've found a culture problem in the styles.xml. When using decimal font sizes, the excel could become invalide, e.g.:
```
<font><sz val="10,5"/><color rgb="FFFFFFFF"/><name val="Calibri"/><family val="2"/><b val="true"/></font>
```
-> invalide xml & excel can't open the file correctly. 

Using the InvariantCultureStreamWriter it creates the correct xml:
```
<font><sz val="10.5"/><color rgb="FFFFFFFF"/><name val="Calibri"/><family val="2"/><b val="true"/></font>
```