### PR TITLE
Add needsSheetRef arg to worksheet constructor

### DIFF
--- a/src/LargeXlsx/Worksheet.cs
+++ b/src/LargeXlsx/Worksheet.cs
@@ -29,6 +29,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+
 using SharpCompress.Writers.Zip;
 
 namespace LargeXlsx
@@ -48,6 +49,7 @@ namespace LargeXlsx
         private string _autoFilterAbsoluteRef;
         private XlsxSheetProtection _sheetProtection;
         private bool _needsRef;
+        private readonly bool _needsSheetRef;
 
         public int Id { get; }
         public string Name { get; }
@@ -55,12 +57,13 @@ namespace LargeXlsx
         public int CurrentColumnNumber { get; private set; }
         internal string AutoFilterAbsoluteRef => _autoFilterAbsoluteRef;
 
-        public Worksheet(ZipWriter zipWriter, int id, string name, int splitRow, int splitColumn, bool rightToLeft, Stylesheet stylesheet, SharedStringTable sharedStringTable, IEnumerable<XlsxColumn> columns)
+        public Worksheet(ZipWriter zipWriter, int id, string name, int splitRow, int splitColumn, bool rightToLeft, bool needsSheetRef, Stylesheet stylesheet, SharedStringTable sharedStringTable, IEnumerable<XlsxColumn> columns)
         {
             Id = id;
             Name = name;
             CurrentRowNumber = 0;
             CurrentColumnNumber = 0;
+            _needsSheetRef = needsSheetRef;
             _stylesheet = stylesheet;
             _sharedStringTable = sharedStringTable;
             _mergedCellRefs = new List<string>();
@@ -101,7 +104,7 @@ namespace LargeXlsx
             CurrentRowNumber++;
             CurrentColumnNumber = 1;
             _streamWriter.Write("<row");
-            if (_needsRef)
+            if (_needsSheetRef || _needsRef)
             {
                 _streamWriter.Write(" r =\"");
                 _streamWriter.Write(CurrentRowNumber);
@@ -271,7 +274,7 @@ namespace LargeXlsx
 
         private void WriteCellRef()
         {
-            if (_needsRef)
+            if (_needsSheetRef || _needsRef)
             {
                 _streamWriter.Write(" r=\"");
                 _streamWriter.Write(Util.GetColumnName(CurrentColumnNumber));

--- a/src/LargeXlsx/XlsxWriter.cs
+++ b/src/LargeXlsx/XlsxWriter.cs
@@ -30,6 +30,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+
 using SharpCompress.Common;
 using SharpCompress.Compressors.Deflate;
 using SharpCompress.Writers;
@@ -178,14 +179,14 @@ namespace LargeXlsx
             }
         }
 
-        public XlsxWriter BeginWorksheet(string name, int splitRow = 0, int splitColumn = 0, bool rightToLeft = false, IEnumerable<XlsxColumn> columns = null)
+        public XlsxWriter BeginWorksheet(string name, int splitRow = 0, int splitColumn = 0, bool rightToLeft = false, IEnumerable<XlsxColumn> columns = null, bool needsSheetRef = false)
         {
             if (name.Length > MaxSheetNameLength)
                 throw new ArgumentException($"The name \"{name}\" exceeds the maximum length of {MaxSheetNameLength} characters supported by Excel");
             if (_worksheets.Any(ws => string.Equals(ws.Name, name, StringComparison.InvariantCultureIgnoreCase)))
                 throw new ArgumentException($"A worksheet named \"{name}\" has already been added");
             _currentWorksheet?.Dispose();
-            _currentWorksheet = new Worksheet(_zipWriter, _worksheets.Count + 1, name, splitRow, splitColumn, rightToLeft, _stylesheet, _sharedStringTable, columns ?? Enumerable.Empty<XlsxColumn>());
+            _currentWorksheet = new Worksheet(_zipWriter, _worksheets.Count + 1, name, splitRow, splitColumn, rightToLeft, needsSheetRef, _stylesheet, _sharedStringTable, columns ?? Enumerable.Empty<XlsxColumn>());
             _worksheets.Add(_currentWorksheet);
             return this;
         }

--- a/tests/LargeXlsx.Tests/LargeXlsx.Tests.csproj
+++ b/tests/LargeXlsx.Tests/LargeXlsx.Tests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="DocumentFormat.OpenXml" Version="2.20.0" />
     <PackageReference Include="EPPlus" Version="4.5.3.3" />
     <PackageReference Include="FluentAssertions" Version="6.10.0" />
     <PackageReference Include="nunit" Version="3.13.3" />


### PR DESCRIPTION
Add boolean needsSheetRef in BeginWorksheet and use it in Worksheet contructor.

If true, always write row and cell reference.
If set to false, write row and cell reference only after SkipRows or SkipColumns