### PR TITLE
Added feature to add header/footer to worksheets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Currently the library supports:
 * cell validation, such as dropdown list of allowed values
 * right-to-left worksheets, to support languages such as Arabic and Hebrew
 * password protection of sheets against accidental modification
+* add plain text headers and footers to worksheet printout
 
 
 ## Example
@@ -181,6 +182,7 @@ public static XlsxColumn Formatted(double width, int count = 1, bool hidden = fa
 `Unformatted` creates a column description that is used basically to skip one or more unformatted columns.
 
 `Formatted` creates a column description to specify the mandatory witdh, optional hidden state, and optional style of one or more contiguous columns. The width is expressed (simplyfing) in approximate number of characters. The column style represents how to style all *empty* cells of a column. Cells that are explicitly written always use the cell style instead.
+
 
 ### Adding or skipping rows
 
@@ -398,6 +400,68 @@ You can call `SetSheetProtection` at any moment while writing a worksheet (that 
 
 **Note:** password protection of sheets is not to be confused with workbook encryption and is not meant to be secure. File contents are still written in clear text and may be changed by deliberately editing the file. The password is not written into the file but a hash of the password is.
 
+### Adding headers and footers to worksheet printout
+
+Call `SetHeaderFooter` when you want to add headers and footers to worksheet printout.
+
+```csharp
+//class XlsxWriter
+public XlsxWriter SetHeaderFooter(XlsxHeaderFooter headerFooter);
+
+//class XlsxHeaderFooter
+public XlsxHeaderFooter(
+        XlsxHeaderFooterText header = null,
+        XlsxHeaderFooterText footer = null,
+        XlsxHeaderFooterText firstHeader = null,
+        XlsxHeaderFooterText firstFooter = null,
+        XlsxHeaderFooterText evenHeader = null,
+        XlsxHeaderFooterText evenFooter = null, 
+        XlsxHeaderFooterSettings settings = null);
+
+//class XlsxHeaderFooterText
+public XlsxHeaderFooterText(
+    string leftAlignedText = null,
+    string centeredText = null, 
+    string rightAlignedText = null);
+```
+
+`XlsxHeaderFooter` takes several properties to control the content of headers or footers.
+- `header` object sets header to use on every page. When `evenHeader` is also set then
+  `header` values will be used only for odd pages.
+- `footer` object sets footer to use on every page. When `evenFooter` is also set then
+  `footer` values will be used only for odd pages.
+- `firstHeader` object sets header to be used only on first page.
+- `firstFooter` object sets footer to be used only on first page.
+- `evenHeader` object sets header to be used only on even pages. When set then
+  `header` values will be used only for odd pages.
+- `evenFooter` object sets footer to be used only on even pages. When set then
+  `footer` values will be used only for odd pages.
+- `settings` takes `XlsxHeaderFooterSettings` object what can be used to set header and footer settings:
+  - `AlignWithMargins`: Align header footer margins with page margins. When true, as left/right margins grow and shrink, the header and footer edges stay aligned with the margins. When false, headers and footers are aligned on the paper edges, regardless of margins. (**Default: `true`**)
+  - `ScaleWithDoc`: Scale header and footer with document scaling. (**Default: `false`**)
+
+`XlsxHeaderFooterText` lets you specify the text that will be displayed in left, center and right section of the header
+or footer.
+
+#### Header and footer codes
+OpenXML standard (ISO/IEC 29500-1) specifies [specific codes](https://learn.microsoft.com/en-us/openspecs/office_standards/ms-oi29500/c167a243-45ad-4def-816e-7032fb1adf5c) what can be used to format header and footer text
+and add dynamic info (For example date time, filename, page number etc.)
+
+`XlsxHeaderFooter` class contains some more common codes as constants:
+- `XlsxHeaderFooter.CurrentDate` "&D": Inserts the current date.
+- `XlsxHeaderFooter.CurrentTime` "&T": Inserts the current time.
+- `XlsxHeaderFooter.FileName` "&F": Inserts the name of workbook file.
+- `XlsxHeaderFooter.FilePath` "&Z": Inserts the workbook file path.
+- `XlsxHeaderFooter.NumberOfPages` "&N": Inserts the total number of pages in a workbook.
+- `XlsxHeaderFooter.PageNumber` "&P": Inserts the current page number.
+- `XlsxHeaderFooter.SheetName` "&A": Inserts the name of a worksheet.
+- `XlsxHeaderFooter.Bold` "&B": Turns bold on or off for the characters that follow.
+- `XlsxHeaderFooter.Italic` "&I": Turns italic on or off for the characters that follow.
+- `XlsxHeaderFooter.Underline` "&U": Turns underline on or off for the characters that follow.
+- `XlsxHeaderFooter.DoubleUnderline` "&E": Turns double underline on or off for the characters that follow.
+- `XlsxHeaderFooter.Strikethrough` "&S": Turns strikethrough on or off for the characters that follow.
+- `XlsxHeaderFooter.Subscript` "&Y": Turns subscript on or off for the characters that follow.
+- `XlsxHeaderFooter.Superscript` "&X": Turns superscript on or off for the characters that follow.
 
 ### Styling
 

--- a/README.md
+++ b/README.md
@@ -420,9 +420,9 @@ public XlsxHeaderFooter(
 
 //class XlsxHeaderFooterText
 public XlsxHeaderFooterText(
-    string leftAlignedText = null,
-    string centeredText = null, 
-    string rightAlignedText = null);
+        string leftAlignedText = null,
+        string centeredText = null, 
+        string rightAlignedText = null);
 ```
 
 `XlsxHeaderFooter` takes several properties to control the content of headers or footers.

--- a/README.md
+++ b/README.md
@@ -407,7 +407,11 @@ Call `SetHeaderFooter` when you want to add headers and footers to worksheet pri
 ```csharp
 //class XlsxWriter
 public XlsxWriter SetHeaderFooter(XlsxHeaderFooter headerFooter);
+```
+Create `XlsxHeaderFooter` using constructor and define header/footer as parameters or clone an existing
+one replacing a property with a `With` method.
 
+```csharp
 //class XlsxHeaderFooter
 public XlsxHeaderFooter(
         XlsxHeaderFooterText header = null,
@@ -415,16 +419,16 @@ public XlsxHeaderFooter(
         XlsxHeaderFooterText firstHeader = null,
         XlsxHeaderFooterText firstFooter = null,
         XlsxHeaderFooterText evenHeader = null,
-        XlsxHeaderFooterText evenFooter = null, 
+        XlsxHeaderFooterText evenFooter = null,
         XlsxHeaderFooterSettings settings = null);
 
-//class XlsxHeaderFooterText
-public XlsxHeaderFooterText(
-        string leftAlignedText = null,
-        string centeredText = null, 
-        string rightAlignedText = null);
+public XlsxHeaderFooter WithHeader(XlsxHeaderFooterText header);
+public XlsxHeaderFooter WithFooter(XlsxHeaderFooterText footer);
+public XlsxHeaderFooter WithFirstHeader(XlsxHeaderFooterText firstHeader);
+public XlsxHeaderFooter WithFirstFooter(XlsxHeaderFooterText firstFooter);
+public XlsxHeaderFooter WithEvenHeader(XlsxHeaderFooterText evenHeader);
+public XlsxHeaderFooter WithEvenFooter(XlsxHeaderFooterText evenFooter);
 ```
-
 `XlsxHeaderFooter` takes several properties to control the content of headers or footers.
 - `header` object sets header to use on every page. When `evenHeader` is also set then
   `header` values will be used only for odd pages.
@@ -443,25 +447,36 @@ public XlsxHeaderFooterText(
 `XlsxHeaderFooterText` lets you specify the text that will be displayed in left, center and right section of the header
 or footer.
 
+```csharp
+//class XlsxHeaderFooterText
+public XlsxHeaderFooterText(
+        string leftAlignedText = null,
+        string centeredText = null, 
+        string rightAlignedText = null);
+```
+
 #### Header and footer codes
 OpenXML standard (ISO/IEC 29500-1) specifies [specific codes](https://learn.microsoft.com/en-us/openspecs/office_standards/ms-oi29500/c167a243-45ad-4def-816e-7032fb1adf5c) what can be used to format header and footer text
 and add dynamic info (For example date time, filename, page number etc.)
 
 `XlsxHeaderFooter` class contains some more common codes as constants:
-- `XlsxHeaderFooter.CurrentDate` "&D": Inserts the current date.
-- `XlsxHeaderFooter.CurrentTime` "&T": Inserts the current time.
-- `XlsxHeaderFooter.FileName` "&F": Inserts the name of workbook file.
-- `XlsxHeaderFooter.FilePath` "&Z": Inserts the workbook file path.
-- `XlsxHeaderFooter.NumberOfPages` "&N": Inserts the total number of pages in a workbook.
-- `XlsxHeaderFooter.PageNumber` "&P": Inserts the current page number.
-- `XlsxHeaderFooter.SheetName` "&A": Inserts the name of a worksheet.
-- `XlsxHeaderFooter.Bold` "&B": Turns bold on or off for the characters that follow.
-- `XlsxHeaderFooter.Italic` "&I": Turns italic on or off for the characters that follow.
-- `XlsxHeaderFooter.Underline` "&U": Turns underline on or off for the characters that follow.
-- `XlsxHeaderFooter.DoubleUnderline` "&E": Turns double underline on or off for the characters that follow.
-- `XlsxHeaderFooter.Strikethrough` "&S": Turns strikethrough on or off for the characters that follow.
-- `XlsxHeaderFooter.Subscript` "&Y": Turns subscript on or off for the characters that follow.
-- `XlsxHeaderFooter.Superscript` "&X": Turns superscript on or off for the characters that follow.
+
+| Constant | Code | Description |
+| --- |:----:| --- |
+| `XlsxHeaderFooter.CurrentDate` |  &D  | Inserts the current date. |
+| `XlsxHeaderFooter.CurrentTime` |  &T  | Inserts the current time. |
+| `XlsxHeaderFooter.FileName` |  &F  | Inserts the name of workbook file. |
+| `XlsxHeaderFooter.FilePath` |  &Z  | Inserts the workbook file path. |
+| `XlsxHeaderFooter.NumberOfPages` |  &N  | Inserts the total number of pages in a workbook. |
+| `XlsxHeaderFooter.PageNumber` |  &P  | Inserts the current page number. |
+| `XlsxHeaderFooter.SheetName` |  &A  | Inserts the name of a worksheet. |
+| `XlsxHeaderFooter.Bold` |  &B  | Turns bold on or off for the characters that follow. |
+| `XlsxHeaderFooter.Italic` |  &I  | Turns italic on or off for the characters that follow. |
+| `XlsxHeaderFooter.Underline` |  &U  | Turns underline on or off for the characters that follow. |
+| `XlsxHeaderFooter.DoubleUnderline` |  &E  | Turns double underline on or off for the characters that follow. |
+| `XlsxHeaderFooter.Strikethrough` |  &S  | Turns strikethrough on or off for the characters that follow. |
+| `XlsxHeaderFooter.Subscript` |  &Y  | Turns subscript on or off for the characters that follow. |
+| `XlsxHeaderFooter.Superscript` |  &X  | Turns superscript on or off for the characters that follow. |
 
 ### Styling
 

--- a/examples/Examples/HeaderFooter.cs
+++ b/examples/Examples/HeaderFooter.cs
@@ -24,15 +24,15 @@ public static class HeaderFooter
 
         var headerFooter = 
             new XlsxHeaderFooter(
-                oddHeader: new XlsxHeaderFooterText($"{XlsxHeaderFooter.Bold}{nameof(HeaderFooter)} Example"),
-                oddFooter: new XlsxHeaderFooterText(
+                new XlsxHeaderFooterText($"{XlsxHeaderFooter.Bold}{nameof(HeaderFooter)} Example"),
+                new XlsxHeaderFooterText(
                     $"Page {XlsxHeaderFooter.PageNumber} of {XlsxHeaderFooter.NumberOfPages}",
                     XlsxHeaderFooter.SheetName,
                     XlsxHeaderFooter.FileName));
         
         xlsxWriter
             .BeginWorksheet("Sheet 1", columns: new[] { XlsxColumn.Unformatted(count: 2), XlsxColumn.Formatted(width: 20) })
-            .SetHeaderFooter(headerFooter)
+            .SetHeaderFooter(headerFooter.WithFirstHeader(new XlsxHeaderFooterText($"{XlsxHeaderFooter.Bold}FirstHeader")))
             .SetDefaultStyle(headerStyle)
             .BeginRow().AddMergedCell(2, 1).Write("Col1").Write("Top2").Write("Top3")
             .BeginRow().Write().Write("Col2").Write("Col3")

--- a/examples/Examples/HeaderFooter.cs
+++ b/examples/Examples/HeaderFooter.cs
@@ -32,7 +32,7 @@ public static class HeaderFooter
         
         xlsxWriter
             .BeginWorksheet("Sheet 1", columns: new[] { XlsxColumn.Unformatted(count: 2), XlsxColumn.Formatted(width: 20) })
-            .SetHeaderFooter(headerFooter.WithFirstHeader(new XlsxHeaderFooterText($"{XlsxHeaderFooter.Bold}FirstHeader")))
+            .SetHeaderFooter(headerFooter)
             .SetDefaultStyle(headerStyle)
             .BeginRow().AddMergedCell(2, 1).Write("Col1").Write("Top2").Write("Top3")
             .BeginRow().Write().Write("Col2").Write("Col3")

--- a/examples/Examples/HeaderFooter.cs
+++ b/examples/Examples/HeaderFooter.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Drawing;
+using System.IO;
+using LargeXlsx;
+
+namespace Examples;
+
+public static class HeaderFooter
+{
+    public static void Run()
+    {
+        using var stream = new FileStream($"{nameof(HeaderFooter)}.xlsx", FileMode.Create, FileAccess.Write);
+        using var xlsxWriter = new XlsxWriter(stream);
+        var headerStyle = new XlsxStyle(
+            new XlsxFont("Segoe UI", 9, Color.White, bold: true),
+            new XlsxFill(Color.FromArgb(0, 0x45, 0x86)),
+            XlsxStyle.Default.Border,
+            XlsxStyle.Default.NumberFormat,
+            XlsxAlignment.Default);
+        var highlightStyle = XlsxStyle.Default.With(new XlsxFill(Color.FromArgb(0xff, 0xff, 0x88)));
+        var dateStyle = XlsxStyle.Default.With(XlsxNumberFormat.ShortDateTime);
+        var borderedStyle = highlightStyle.With(XlsxBorder.Around(new XlsxBorder.Line(Color.DeepPink, XlsxBorder.Style.Dashed)));
+        var hyperlinkStyle = XlsxStyle.Default.With(XlsxFont.Default.WithUnderline().With(Color.Blue));
+
+        var headerFooter = 
+            new XlsxHeaderFooter(
+                oddHeader: new XlsxHeaderFooterText($"{XlsxHeaderFooter.Bold}{nameof(HeaderFooter)} Example"),
+                oddFooter: new XlsxHeaderFooterText(
+                    $"Page {XlsxHeaderFooter.PageNumber} of {XlsxHeaderFooter.NumberOfPages}",
+                    XlsxHeaderFooter.SheetName,
+                    XlsxHeaderFooter.FileName));
+        
+        xlsxWriter
+            .BeginWorksheet("Sheet 1", columns: new[] { XlsxColumn.Unformatted(count: 2), XlsxColumn.Formatted(width: 20) })
+            .SetHeaderFooter(headerFooter)
+            .SetDefaultStyle(headerStyle)
+            .BeginRow().AddMergedCell(2, 1).Write("Col1").Write("Top2").Write("Top3")
+            .BeginRow().Write().Write("Col2").Write("Col3")
+            .SetDefaultStyle(XlsxStyle.Default)
+            .BeginRow().Write("Row3").Write(42).WriteFormula(
+                $"{xlsxWriter.GetRelativeColumnName(-1)}{xlsxWriter.CurrentRowNumber}*10", highlightStyle)
+            .BeginRow().Write("Row4").SkipColumns(1).Write(new DateTime(2020, 5, 6, 18, 27, 0), dateStyle)
+            .SkipRows(2)
+            .BeginRow().Write("Row7", borderedStyle, columnSpan: 2).Write(3.14159265359)
+            .BeginRow().Write("Bold").Write().Write("Be bold", XlsxStyle.Default.With(XlsxFont.Default.WithBold()))
+            .BeginRow().Write("Italic").Write().Write("Be italic", XlsxStyle.Default.With(XlsxFont.Default.WithItalic()))
+            .BeginRow().Write("Strike").Write().Write("Be struck", XlsxStyle.Default.With(XlsxFont.Default.WithStrike()))
+            .BeginRow().Write("Underline").Write().Write("Single", XlsxStyle.Default.With(XlsxFont.Default.WithUnderline()))
+            .BeginRow().Write("Underline").Write().Write("Double", XlsxStyle.Default.With(XlsxFont.Default.WithUnderline(XlsxFont.Underline.Double)))
+            .BeginRow().Write("Underline").Write().Write("SingleAccounting", XlsxStyle.Default.With(XlsxFont.Default.WithUnderline(XlsxFont.Underline.SingleAccounting)))
+            .BeginRow().Write("Underline").Write().Write("DoubleAccounting", XlsxStyle.Default.With(XlsxFont.Default.WithUnderline(XlsxFont.Underline.DoubleAccounting)))
+            .BeginRow().Write("Hyperlink").Write().WriteFormula("HYPERLINK(\"https://github.com/salvois/LargeXlsx\")", hyperlinkStyle)
+            .BeginRow().Write("Hyperlink w/alias").Write().WriteFormula("HYPERLINK(\"https://github.com/salvois/LargeXlsx\", \"LargeXlsx on GitHub\")", hyperlinkStyle)
+            .BeginRow().Write("Boolean").Write(false).Write(true)
+            .SetAutoFilter(2, 1, xlsxWriter.CurrentRowNumber - 1, 3);
+    }
+}

--- a/examples/Examples/Program.cs
+++ b/examples/Examples/Program.cs
@@ -48,5 +48,6 @@ public static class Program
         StyledLarge.Run();
         StyledLargeCreateStyles.Run();
         Zip64Huge.Run();
+        HeaderFooter.Run();
     }
 }

--- a/src/LargeXlsx/Worksheet.cs
+++ b/src/LargeXlsx/Worksheet.cs
@@ -437,7 +437,12 @@ namespace LargeXlsx
         {
             if (_headerFooter == null)
                 return;
-            _streamWriter.Write("<headerFooter alignWithMargins=\"{0}\" differentFirst=\"{1}\" differentOddEven=\"{2}\" scaleWithDoc=\"{3}\">", Util.BoolToInt(_headerFooter.Settings.AlignWithMargins), Util.BoolToInt(_headerFooter.Settings.DifferentFirst), Util.BoolToInt(_headerFooter.Settings.DifferentOddEven), Util.BoolToInt(_headerFooter.Settings.ScaleWithDoc));
+            
+            // Different first page header and footer.
+            var differentFirst = _headerFooter.FirstHeader != null || _headerFooter.FirstFooter != null;
+            // Different odd and even page headers and footers.
+            var differentOddEven = _headerFooter.EvenHeader != null || _headerFooter.EvenFooter != null;
+            _streamWriter.Write("<headerFooter alignWithMargins=\"{0}\" differentFirst=\"{1}\" differentOddEven=\"{2}\" scaleWithDoc=\"{3}\">", Util.BoolToInt(_headerFooter.Settings.AlignWithMargins), Util.BoolToInt(differentFirst), Util.BoolToInt(differentOddEven), Util.BoolToInt(_headerFooter.Settings.ScaleWithDoc));
             if (_headerFooter.OddHeader != null) _streamWriter.Write("<oddHeader>{0}</oddHeader>", Util.EscapeXmlText(_headerFooter.OddHeader.WriteText()));
             if (_headerFooter.OddFooter != null) _streamWriter.Write("<oddFooter>{0}</oddFooter>", Util.EscapeXmlText(_headerFooter.OddFooter.WriteText()));
             if (_headerFooter.EvenHeader != null) _streamWriter.Write("<evenHeader>{0}</evenHeader>", Util.EscapeXmlText(_headerFooter.EvenHeader.WriteText()));

--- a/src/LargeXlsx/Worksheet.cs
+++ b/src/LargeXlsx/Worksheet.cs
@@ -442,12 +442,12 @@ namespace LargeXlsx
             if (_headerFooter == null)
                 return;
             _streamWriter.Write("<headerFooter alignWithMargins=\"{0}\" differentFirst=\"{1}\" differentOddEven=\"{2}\" scaleWithDoc=\"{3}\">", Util.BoolToInt(_headerFooter.AlignWithMargins), Util.BoolToInt(_headerFooter.DifferentFirst), Util.BoolToInt(_headerFooter.DifferentOddEven), Util.BoolToInt(_headerFooter.ScaleWithDoc));
-            if (_headerFooter.OddHeader != null) _streamWriter.Write("<oddHeader>{0}</oddHeader>", Util.EscapeXmlText(_headerFooter.OddHeader));
-            if (_headerFooter.OddFooter != null) _streamWriter.Write("<oddFooter>{0}</oddFooter>", Util.EscapeXmlText(_headerFooter.OddFooter));
-            if (_headerFooter.EvenHeader != null) _streamWriter.Write("<evenHeader>{0}</evenHeader>", Util.EscapeXmlText(_headerFooter.EvenHeader));
-            if (_headerFooter.EvenFooter != null) _streamWriter.Write("<evenFooter>{0}</evenFooter>", Util.EscapeXmlText(_headerFooter.EvenFooter));
-            if (_headerFooter.FirstHeader != null) _streamWriter.Write("<firstHeader>{0}</firstHeader>", Util.EscapeXmlText(_headerFooter.FirstHeader));
-            if (_headerFooter.FirstFooter != null) _streamWriter.Write("<firstFooter>{0}</firstFooter>", Util.EscapeXmlText(_headerFooter.FirstFooter));
+            if (_headerFooter.OddHeader != null) _streamWriter.Write("<oddHeader>{0}</oddHeader>", Util.EscapeXmlText(_headerFooter.OddHeader.WriteText()));
+            if (_headerFooter.OddFooter != null) _streamWriter.Write("<oddFooter>{0}</oddFooter>", Util.EscapeXmlText(_headerFooter.OddFooter.WriteText()));
+            if (_headerFooter.EvenHeader != null) _streamWriter.Write("<evenHeader>{0}</evenHeader>", Util.EscapeXmlText(_headerFooter.EvenHeader.WriteText()));
+            if (_headerFooter.EvenFooter != null) _streamWriter.Write("<evenFooter>{0}</evenFooter>", Util.EscapeXmlText(_headerFooter.EvenFooter.WriteText()));
+            if (_headerFooter.FirstHeader != null) _streamWriter.Write("<firstHeader>{0}</firstHeader>", Util.EscapeXmlText(_headerFooter.FirstHeader.WriteText()));
+            if (_headerFooter.FirstFooter != null) _streamWriter.Write("<firstFooter>{0}</firstFooter>", Util.EscapeXmlText(_headerFooter.FirstFooter.WriteText()));
             _streamWriter.Write("</headerFooter>");
         }
     }

--- a/src/LargeXlsx/Worksheet.cs
+++ b/src/LargeXlsx/Worksheet.cs
@@ -47,6 +47,7 @@ namespace LargeXlsx
         private string _autoFilterRef;
         private string _autoFilterAbsoluteRef;
         private XlsxSheetProtection _sheetProtection;
+        private XlsxHeaderFooter _headerFooter;
         private bool _needsRef;
 
         public int Id { get; }
@@ -90,6 +91,7 @@ namespace LargeXlsx
             WriteAutoFilter();
             WriteMergedCells();
             WriteDataValidations();
+            WriteHeaderFooter();
             _streamWriter.Write("</worksheet>\n");
             _streamWriter.Dispose();
             _stream.Dispose();
@@ -271,6 +273,11 @@ namespace LargeXlsx
             _sheetProtection = sheetProtection;
         }
 
+        public void SetHeaderFooter(XlsxHeaderFooter headerFooter)
+        {
+            _headerFooter = headerFooter;
+        }
+        
         private void WriteCellRef()
         {
             if (_needsRef)
@@ -424,6 +431,20 @@ namespace LargeXlsx
             if (!_sheetProtection.PivotTables) _streamWriter.Write(" pivotTables=\"0\"");
             if (_sheetProtection.SelectUnlockedCells) _streamWriter.Write(" selectUnlockedCells=\"1\"");
             _streamWriter.Write("/>\n");
+        }
+
+        private void WriteHeaderFooter()
+        {
+            if (_headerFooter == null)
+                return;
+            _streamWriter.Write("<headerFooter alignWithMargins=\"{0}\" differentFirst=\"{1}\" differentOddEven=\"{2}\" scaleWithDoc=\"{3}\">", Util.BoolToInt(_headerFooter.AlignWithMargins), Util.BoolToInt(_headerFooter.DifferentFirst), Util.BoolToInt(_headerFooter.DifferentOddEven), Util.BoolToInt(_headerFooter.ScaleWithDoc));
+            if (_headerFooter.EvenHeader != null) _streamWriter.Write("<evenHeader>{0}</evenHeader>", Util.EscapeXmlText(_headerFooter.EvenHeader));
+            if (_headerFooter.EvenFooter != null) _streamWriter.Write("<evenFooter>{0}</evenFooter>", Util.EscapeXmlText(_headerFooter.EvenFooter));
+            if (_headerFooter.OddHeader != null) _streamWriter.Write("<oddHeader>{0}</oddHeader>", Util.EscapeXmlText(_headerFooter.OddHeader));
+            if (_headerFooter.OddFooter != null) _streamWriter.Write("<oddFooter>{0}</oddFooter>", Util.EscapeXmlText(_headerFooter.OddFooter));
+            if (_headerFooter.FirstHeader != null) _streamWriter.Write("<firstHeader>{0}</firstHeader>", Util.EscapeXmlText(_headerFooter.FirstHeader));
+            if (_headerFooter.FirstFooter != null) _streamWriter.Write("<firstFooter>{0}</firstFooter>", Util.EscapeXmlText(_headerFooter.FirstFooter));
+            _streamWriter.Write("</headerFooter>");
         }
     }
 }

--- a/src/LargeXlsx/Worksheet.cs
+++ b/src/LargeXlsx/Worksheet.cs
@@ -275,10 +275,10 @@ namespace LargeXlsx
 
         public void SetHeaderFooter(XlsxHeaderFooter headerFooter)
         {
-            if (!headerFooter.DifferentOddEven && headerFooter.OddHeader == null)
-                throw new ArgumentException("When different header for odd and even pages is not used OddHeader value must be set");
-            if (!headerFooter.DifferentOddEven && headerFooter.OddFooter == null)
-                throw new ArgumentException("When different footer for odd and even pages is not used OddFooter value must be set");
+            if (!headerFooter.Settings.DifferentOddEven && headerFooter.OddHeader == null)
+                throw new ArgumentException("When different header for odd and even pages is not used Header value must be set");
+            if (!headerFooter.Settings.DifferentOddEven && headerFooter.OddFooter == null)
+                throw new ArgumentException("When different footer for odd and even pages is not used Footer value must be set");
             _headerFooter = headerFooter;
         }
         
@@ -441,7 +441,7 @@ namespace LargeXlsx
         {
             if (_headerFooter == null)
                 return;
-            _streamWriter.Write("<headerFooter alignWithMargins=\"{0}\" differentFirst=\"{1}\" differentOddEven=\"{2}\" scaleWithDoc=\"{3}\">", Util.BoolToInt(_headerFooter.AlignWithMargins), Util.BoolToInt(_headerFooter.DifferentFirst), Util.BoolToInt(_headerFooter.DifferentOddEven), Util.BoolToInt(_headerFooter.ScaleWithDoc));
+            _streamWriter.Write("<headerFooter alignWithMargins=\"{0}\" differentFirst=\"{1}\" differentOddEven=\"{2}\" scaleWithDoc=\"{3}\">", Util.BoolToInt(_headerFooter.Settings.AlignWithMargins), Util.BoolToInt(_headerFooter.Settings.DifferentFirst), Util.BoolToInt(_headerFooter.Settings.DifferentOddEven), Util.BoolToInt(_headerFooter.Settings.ScaleWithDoc));
             if (_headerFooter.OddHeader != null) _streamWriter.Write("<oddHeader>{0}</oddHeader>", Util.EscapeXmlText(_headerFooter.OddHeader.WriteText()));
             if (_headerFooter.OddFooter != null) _streamWriter.Write("<oddFooter>{0}</oddFooter>", Util.EscapeXmlText(_headerFooter.OddFooter.WriteText()));
             if (_headerFooter.EvenHeader != null) _streamWriter.Write("<evenHeader>{0}</evenHeader>", Util.EscapeXmlText(_headerFooter.EvenHeader.WriteText()));

--- a/src/LargeXlsx/Worksheet.cs
+++ b/src/LargeXlsx/Worksheet.cs
@@ -275,10 +275,6 @@ namespace LargeXlsx
 
         public void SetHeaderFooter(XlsxHeaderFooter headerFooter)
         {
-            if (!headerFooter.Settings.DifferentOddEven && headerFooter.OddHeader == null)
-                throw new ArgumentException("When different header for odd and even pages is not used Header value must be set");
-            if (!headerFooter.Settings.DifferentOddEven && headerFooter.OddFooter == null)
-                throw new ArgumentException("When different footer for odd and even pages is not used Footer value must be set");
             _headerFooter = headerFooter;
         }
         

--- a/src/LargeXlsx/Worksheet.cs
+++ b/src/LargeXlsx/Worksheet.cs
@@ -275,6 +275,10 @@ namespace LargeXlsx
 
         public void SetHeaderFooter(XlsxHeaderFooter headerFooter)
         {
+            if (!headerFooter.DifferentOddEven && headerFooter.OddHeader == null)
+                throw new ArgumentException("When different header for odd and even pages is not used OddHeader value must be set");
+            if (!headerFooter.DifferentOddEven && headerFooter.OddFooter == null)
+                throw new ArgumentException("When different footer for odd and even pages is not used OddFooter value must be set");
             _headerFooter = headerFooter;
         }
         
@@ -438,10 +442,10 @@ namespace LargeXlsx
             if (_headerFooter == null)
                 return;
             _streamWriter.Write("<headerFooter alignWithMargins=\"{0}\" differentFirst=\"{1}\" differentOddEven=\"{2}\" scaleWithDoc=\"{3}\">", Util.BoolToInt(_headerFooter.AlignWithMargins), Util.BoolToInt(_headerFooter.DifferentFirst), Util.BoolToInt(_headerFooter.DifferentOddEven), Util.BoolToInt(_headerFooter.ScaleWithDoc));
-            if (_headerFooter.EvenHeader != null) _streamWriter.Write("<evenHeader>{0}</evenHeader>", Util.EscapeXmlText(_headerFooter.EvenHeader));
-            if (_headerFooter.EvenFooter != null) _streamWriter.Write("<evenFooter>{0}</evenFooter>", Util.EscapeXmlText(_headerFooter.EvenFooter));
             if (_headerFooter.OddHeader != null) _streamWriter.Write("<oddHeader>{0}</oddHeader>", Util.EscapeXmlText(_headerFooter.OddHeader));
             if (_headerFooter.OddFooter != null) _streamWriter.Write("<oddFooter>{0}</oddFooter>", Util.EscapeXmlText(_headerFooter.OddFooter));
+            if (_headerFooter.EvenHeader != null) _streamWriter.Write("<evenHeader>{0}</evenHeader>", Util.EscapeXmlText(_headerFooter.EvenHeader));
+            if (_headerFooter.EvenFooter != null) _streamWriter.Write("<evenFooter>{0}</evenFooter>", Util.EscapeXmlText(_headerFooter.EvenFooter));
             if (_headerFooter.FirstHeader != null) _streamWriter.Write("<firstHeader>{0}</firstHeader>", Util.EscapeXmlText(_headerFooter.FirstHeader));
             if (_headerFooter.FirstFooter != null) _streamWriter.Write("<firstFooter>{0}</firstFooter>", Util.EscapeXmlText(_headerFooter.FirstFooter));
             _streamWriter.Write("</headerFooter>");

--- a/src/LargeXlsx/XlsxHeaderFooter.cs
+++ b/src/LargeXlsx/XlsxHeaderFooter.cs
@@ -1,0 +1,52 @@
+﻿namespace LargeXlsx
+{
+    public class XlsxHeaderFooter
+    {
+        /// <summary>
+        /// Align header footer margins with page margins.
+        /// </summary>
+        public bool AlignWithMargins { get; }
+        /// <summary>
+        /// Different first page header and footer.
+        /// </summary>
+        public bool DifferentFirst { get; }
+        /// <summary>
+        /// Different odd and even page headers and footers.
+        /// </summary>
+        public bool DifferentOddEven { get; }
+        /// <summary>
+        /// Scale header and footer with document scaling.
+        /// </summary>
+        public bool ScaleWithDoc { get; }
+        public string EvenFooter { get; }
+        public string EvenHeader { get; }
+        public string FirstFooter { get; }
+        public string FirstHeader { get; }
+        public string OddFooter { get; }
+        public string OddHeader { get; }
+        
+        public XlsxHeaderFooter(
+            bool alignWithMargins = true, 
+            bool differentFirst = false, 
+            bool differentOddEven = false, 
+            bool scaleWithDoc = false, 
+            string evenFooter = null, 
+            string evenHeader = null, 
+            string firstFooter = null, 
+            string firstHeader = null, 
+            string oddFooter = null, 
+            string oddHeader = null)
+        {
+            AlignWithMargins = alignWithMargins;
+            DifferentFirst = differentFirst;
+            DifferentOddEven = differentOddEven;
+            ScaleWithDoc = scaleWithDoc;
+            EvenFooter = evenFooter;
+            EvenHeader = evenHeader;
+            FirstFooter = firstFooter;
+            FirstHeader = firstHeader;
+            OddFooter = oddFooter;
+            OddHeader = oddHeader;
+        }
+    }
+}

--- a/src/LargeXlsx/XlsxHeaderFooter.cs
+++ b/src/LargeXlsx/XlsxHeaderFooter.cs
@@ -47,14 +47,6 @@ namespace LargeXlsx
         /// </summary>
         public bool AlignWithMargins { get; }
         /// <summary>
-        /// Different first page header and footer.
-        /// </summary>
-        public bool DifferentFirst { get; set; }
-        /// <summary>
-        /// Different odd and even page headers and footers.
-        /// </summary>
-        public bool DifferentOddEven { get; set; }
-        /// <summary>
         /// Scale header and footer with document scaling.
         /// </summary>
         public bool ScaleWithDoc { get; }
@@ -143,12 +135,7 @@ namespace LargeXlsx
             OddFooter = footer;
             OddHeader = header;
             
-            if (settings == null)
-                settings = XlsxHeaderFooterSettings.Default;
-
-            Settings = settings;
-            Settings.DifferentFirst = FirstHeader != null || FirstFooter != null;
-            Settings.DifferentOddEven = EvenHeader != null || EvenFooter != null;
+            Settings = settings ?? XlsxHeaderFooterSettings.Default;
         }
 
         public XlsxHeaderFooter WithHeader(XlsxHeaderFooterText header) =>

--- a/src/LargeXlsx/XlsxHeaderFooter.cs
+++ b/src/LargeXlsx/XlsxHeaderFooter.cs
@@ -1,7 +1,96 @@
-﻿namespace LargeXlsx
+﻿using System.Runtime.CompilerServices;
+
+namespace LargeXlsx
 {
+    public class XlsxHeaderFooterText
+    {
+        public string CenteredText { get; }
+        public string LeftAlignedText { get; }
+        public string RightAlignedText { get; }
+
+        public XlsxHeaderFooterText(
+            string leftAlignedText = null,
+            string centeredText = null, 
+            string rightAlignedText = null)
+        {
+            CenteredText = centeredText;
+            LeftAlignedText = leftAlignedText;
+            RightAlignedText = rightAlignedText;
+        }
+
+        public string WriteText()
+        {
+            var text = "";
+            if (LeftAlignedText != null)
+                text += $"&L{LeftAlignedText}";
+            if (CenteredText != null)
+                text += $"&C{CenteredText}";
+            if (RightAlignedText != null)
+                text += $"&R{RightAlignedText}";
+
+            return text;
+        }
+    }
+    
     public class XlsxHeaderFooter
     {
+        /// <summary>
+        /// Inserts the current date.
+        /// </summary>
+        public const string CurrentDate = "&D";
+        /// <summary>
+        /// Inserts the current time.
+        /// </summary>
+        public const string CurrentTime = "&T";
+        /// <summary>
+        /// Inserts the name of workbook file.
+        /// </summary>
+        public const string FileName = "&F";
+        /// <summary>
+        /// Inserts the workbook file path.
+        /// </summary>
+        public const string FilePath = "&Z";
+        /// <summary>
+        /// Inserts the total number of pages in a workbook.
+        /// </summary>
+        public const string NumberOfPages = "&N";
+        /// <summary>
+        /// Inserts the current page number.
+        /// </summary>
+        public const string PageNumber = "&P";
+        /// <summary>
+        /// Inserts the name of a worksheet.
+        /// </summary>
+        public const string SheetName = "&A";
+        /// <summary>
+        /// Turns bold on or off for the characters that follow.
+        /// </summary>
+        public const string Bold = "&B";
+        /// <summary>
+        /// Turns italic on or off for the characters that follow.
+        /// </summary>
+        public const string Italic = "&I";
+        /// <summary>
+        /// Turns underline on or off for the characters that follow.
+        /// </summary>
+        public const string Underline = "&U";
+        /// <summary>
+        /// Turns double underline on or off for the characters that follow.
+        /// </summary>
+        public const string DoubleUnderline = "&E";
+        /// <summary>
+        /// Turns strikethrough on or off for the characters that follow.
+        /// </summary>
+        public const string Strikethrough = "&S";
+        /// <summary>
+        /// Turns subscript on or off for the characters that follow.
+        /// </summary>
+        public const string Subscript = "&Y";
+        /// <summary>
+        /// Turns superscript on or off for the characters that follow.
+        /// </summary>
+        public const string Superscript = "&X";
+        
         /// <summary>
         /// Align header footer margins with page margins.
         /// </summary>
@@ -18,24 +107,24 @@
         /// Scale header and footer with document scaling.
         /// </summary>
         public bool ScaleWithDoc { get; }
-        public string EvenFooter { get; }
-        public string EvenHeader { get; }
-        public string FirstFooter { get; }
-        public string FirstHeader { get; }
-        public string OddFooter { get; }
-        public string OddHeader { get; }
+        public XlsxHeaderFooterText EvenFooter { get; }
+        public XlsxHeaderFooterText EvenHeader { get; }
+        public XlsxHeaderFooterText FirstFooter { get; }
+        public XlsxHeaderFooterText FirstHeader { get; }
+        public XlsxHeaderFooterText OddFooter { get; }
+        public XlsxHeaderFooterText OddHeader { get; }
         
         public XlsxHeaderFooter(
             bool alignWithMargins = true, 
             bool differentFirst = false, 
             bool differentOddEven = false, 
             bool scaleWithDoc = false, 
-            string evenFooter = null, 
-            string evenHeader = null, 
-            string firstFooter = null, 
-            string firstHeader = null, 
-            string oddFooter = null, 
-            string oddHeader = null)
+            XlsxHeaderFooterText evenFooter = null, 
+            XlsxHeaderFooterText evenHeader = null, 
+            XlsxHeaderFooterText firstFooter = null, 
+            XlsxHeaderFooterText firstHeader = null, 
+            XlsxHeaderFooterText oddFooter = null, 
+            XlsxHeaderFooterText oddHeader = null)
         {
             AlignWithMargins = alignWithMargins;
             DifferentFirst = differentFirst;

--- a/src/LargeXlsx/XlsxHeaderFooter.cs
+++ b/src/LargeXlsx/XlsxHeaderFooter.cs
@@ -128,8 +128,8 @@ namespace LargeXlsx
         public XlsxHeaderFooterSettings Settings { get; }
         
         public XlsxHeaderFooter(
-            XlsxHeaderFooterText header,
-            XlsxHeaderFooterText footer,
+            XlsxHeaderFooterText header = null,
+            XlsxHeaderFooterText footer = null,
             XlsxHeaderFooterText firstHeader = null,
             XlsxHeaderFooterText firstFooter = null,
             XlsxHeaderFooterText evenHeader = null,
@@ -151,6 +151,10 @@ namespace LargeXlsx
             Settings.DifferentOddEven = EvenHeader != null || EvenFooter != null;
         }
 
+        public XlsxHeaderFooter WithHeader(XlsxHeaderFooterText header) =>
+            new XlsxHeaderFooter(header, OddFooter, FirstHeader, FirstFooter, EvenHeader, EvenFooter, Settings);
+        public XlsxHeaderFooter WithFooter(XlsxHeaderFooterText footer) =>
+            new XlsxHeaderFooter(OddHeader, footer, FirstHeader, FirstFooter, EvenHeader, EvenFooter, Settings);
         public XlsxHeaderFooter WithFirstHeader(XlsxHeaderFooterText firstHeader) =>
             new XlsxHeaderFooter(OddHeader, OddFooter, firstHeader, FirstFooter, EvenHeader, EvenFooter, Settings);
         public XlsxHeaderFooter WithFirstFooter(XlsxHeaderFooterText firstFooter) =>

--- a/src/LargeXlsx/XlsxHeaderFooter.cs
+++ b/src/LargeXlsx/XlsxHeaderFooter.cs
@@ -32,6 +32,34 @@ namespace LargeXlsx
         }
     }
     
+    public class XlsxHeaderFooterSettings
+    {
+        public static readonly XlsxHeaderFooterSettings Default = new XlsxHeaderFooterSettings(true, false);
+
+        public XlsxHeaderFooterSettings(bool alignWithMargins, bool scaleWithDoc)
+        {
+            AlignWithMargins = alignWithMargins;
+            ScaleWithDoc = scaleWithDoc;
+        }
+
+        /// <summary>
+        /// Align header footer margins with page margins.
+        /// </summary>
+        public bool AlignWithMargins { get; }
+        /// <summary>
+        /// Different first page header and footer.
+        /// </summary>
+        public bool DifferentFirst { get; set; }
+        /// <summary>
+        /// Different odd and even page headers and footers.
+        /// </summary>
+        public bool DifferentOddEven { get; set; }
+        /// <summary>
+        /// Scale header and footer with document scaling.
+        /// </summary>
+        public bool ScaleWithDoc { get; }
+    }
+    
     public class XlsxHeaderFooter
     {
         /// <summary>
@@ -91,51 +119,45 @@ namespace LargeXlsx
         /// </summary>
         public const string Superscript = "&X";
         
-        /// <summary>
-        /// Align header footer margins with page margins.
-        /// </summary>
-        public bool AlignWithMargins { get; }
-        /// <summary>
-        /// Different first page header and footer.
-        /// </summary>
-        public bool DifferentFirst { get; }
-        /// <summary>
-        /// Different odd and even page headers and footers.
-        /// </summary>
-        public bool DifferentOddEven { get; }
-        /// <summary>
-        /// Scale header and footer with document scaling.
-        /// </summary>
-        public bool ScaleWithDoc { get; }
         public XlsxHeaderFooterText EvenFooter { get; }
         public XlsxHeaderFooterText EvenHeader { get; }
         public XlsxHeaderFooterText FirstFooter { get; }
         public XlsxHeaderFooterText FirstHeader { get; }
         public XlsxHeaderFooterText OddFooter { get; }
         public XlsxHeaderFooterText OddHeader { get; }
+        public XlsxHeaderFooterSettings Settings { get; }
         
         public XlsxHeaderFooter(
-            bool alignWithMargins = true, 
-            bool differentFirst = false, 
-            bool differentOddEven = false, 
-            bool scaleWithDoc = false, 
+            XlsxHeaderFooterText header,
+            XlsxHeaderFooterText footer,
+            XlsxHeaderFooterText firstHeader = null,
+            XlsxHeaderFooterText firstFooter = null,
+            XlsxHeaderFooterText evenHeader = null,
             XlsxHeaderFooterText evenFooter = null, 
-            XlsxHeaderFooterText evenHeader = null, 
-            XlsxHeaderFooterText firstFooter = null, 
-            XlsxHeaderFooterText firstHeader = null, 
-            XlsxHeaderFooterText oddFooter = null, 
-            XlsxHeaderFooterText oddHeader = null)
+            XlsxHeaderFooterSettings settings = null)
         {
-            AlignWithMargins = alignWithMargins;
-            DifferentFirst = differentFirst;
-            DifferentOddEven = differentOddEven;
-            ScaleWithDoc = scaleWithDoc;
             EvenFooter = evenFooter;
             EvenHeader = evenHeader;
             FirstFooter = firstFooter;
             FirstHeader = firstHeader;
-            OddFooter = oddFooter;
-            OddHeader = oddHeader;
+            OddFooter = footer;
+            OddHeader = header;
+            
+            if (settings == null)
+                settings = XlsxHeaderFooterSettings.Default;
+
+            Settings = settings;
+            Settings.DifferentFirst = FirstHeader != null || FirstFooter != null;
+            Settings.DifferentOddEven = EvenHeader != null || EvenFooter != null;
         }
+
+        public XlsxHeaderFooter WithFirstHeader(XlsxHeaderFooterText firstHeader) =>
+            new XlsxHeaderFooter(OddHeader, OddFooter, firstHeader, FirstFooter, EvenHeader, EvenFooter, Settings);
+        public XlsxHeaderFooter WithFirstFooter(XlsxHeaderFooterText firstFooter) =>
+            new XlsxHeaderFooter(OddHeader, OddFooter, FirstHeader, firstFooter, EvenHeader, EvenFooter, Settings);
+        public XlsxHeaderFooter WithEvenHeader(XlsxHeaderFooterText evenHeader) =>
+            new XlsxHeaderFooter(OddHeader, OddFooter, FirstHeader, FirstFooter, evenHeader, EvenFooter, Settings);
+        public XlsxHeaderFooter WithEvenFooter(XlsxHeaderFooterText evenFooter) =>
+            new XlsxHeaderFooter(OddHeader, OddFooter, FirstHeader, FirstFooter, EvenHeader, evenFooter, Settings);
     }
 }

--- a/src/LargeXlsx/XlsxWriter.cs
+++ b/src/LargeXlsx/XlsxWriter.cs
@@ -350,6 +350,13 @@ namespace LargeXlsx
             return this;
         }
 
+        public XlsxWriter SetHeaderFooter(XlsxHeaderFooter headerFooter)
+        {
+            CheckInWorksheet();
+            _currentWorksheet.SetHeaderFooter(headerFooter);
+            return this;
+        }
+        
         private void CheckInWorksheet()
         {
             if (_currentWorksheet == null)

--- a/tests/LargeXlsx.Tests/XlsxWriterTest.cs
+++ b/tests/LargeXlsx.Tests/XlsxWriterTest.cs
@@ -447,4 +447,36 @@ public static class XlsxWriterTest
             sheet.Cells["A6"].Value.Should().Be("Lorem ipsum dolor sit amet");
         }
     }
+
+    [Test]
+    public static void HeaderFooter()
+    {
+        using var stream = new MemoryStream();
+        using (var xlsxWriter = new XlsxWriter(stream))
+        {
+            var headerFooter = 
+                new XlsxHeaderFooter(
+                    alignWithMargins: true,
+                    differentFirst: false,
+                    differentOddEven: false,
+                    scaleWithDoc: false,
+                    evenHeader: "&LLeftHeader&CCenterHeader&RRightHeader"
+                    );
+            xlsxWriter
+                .BeginWorksheet("HeaderFooterTest")
+                .SetHeaderFooter(headerFooter);
+        }
+
+        using (var package = new ExcelPackage(stream))
+        {
+            var sheet = package.Workbook.Worksheets[0];
+            sheet.HeaderFooter.AlignWithMargins.Should().BeTrue();
+            sheet.HeaderFooter.differentFirst.Should().BeFalse();
+            sheet.HeaderFooter.differentOddEven.Should().BeFalse();
+            sheet.HeaderFooter.ScaleWithDocument.Should().BeFalse();
+            sheet.HeaderFooter.EvenHeader.LeftAlignedText.Should().Be("LeftHeader");
+            sheet.HeaderFooter.EvenHeader.CenteredText.Should().Be("CenterHeader");
+            sheet.HeaderFooter.EvenHeader.RightAlignedText.Should().Be("RightHeader");
+        }
+    }
 }

--- a/tests/LargeXlsx.Tests/XlsxWriterTest.cs
+++ b/tests/LargeXlsx.Tests/XlsxWriterTest.cs
@@ -456,20 +456,15 @@ public static class XlsxWriterTest
         {
             var headerFooter = 
                 new XlsxHeaderFooter(
-                    alignWithMargins: true,
-                    differentFirst: true,
-                    differentOddEven: false,
-                    scaleWithDoc: false,
-                    firstHeader: new XlsxHeaderFooterText($"{XlsxHeaderFooter.Bold}FirstHeader"),
-                    oddHeader: new XlsxHeaderFooterText(
+                    new XlsxHeaderFooterText(
                         $"{XlsxHeaderFooter.Bold}LeftHeader", 
                         $"{XlsxHeaderFooter.Underline}CenterHeader", 
                         $"{XlsxHeaderFooter.Strikethrough}RightHeader"),
-                    oddFooter: new XlsxHeaderFooterText("LeftFooter", "CenterFooter", "RightFooter")
-                    );
+                    new XlsxHeaderFooterText("LeftFooter", "CenterFooter", "RightFooter"));
             xlsxWriter
                 .BeginWorksheet("HeaderFooterTest")
-                .SetHeaderFooter(headerFooter);
+                .SetHeaderFooter(headerFooter
+                    .WithFirstHeader(new XlsxHeaderFooterText($"{XlsxHeaderFooter.Bold}FirstHeader")));
         }
 
         using (var package = new ExcelPackage(stream))
@@ -477,6 +472,7 @@ public static class XlsxWriterTest
             var sheet = package.Workbook.Worksheets[0];
             sheet.HeaderFooter.AlignWithMargins.Should().BeTrue();
             sheet.HeaderFooter.differentFirst.Should().BeTrue();
+            sheet.HeaderFooter.FirstHeader.LeftAlignedText.Should().Be("&BFirstHeader");
             sheet.HeaderFooter.differentOddEven.Should().BeFalse();
             sheet.HeaderFooter.ScaleWithDocument.Should().BeFalse();
             sheet.HeaderFooter.OddHeader.LeftAlignedText.Should().Be("&BLeftHeader");

--- a/tests/LargeXlsx.Tests/XlsxWriterTest.cs
+++ b/tests/LargeXlsx.Tests/XlsxWriterTest.cs
@@ -460,9 +460,12 @@ public static class XlsxWriterTest
                     differentFirst: true,
                     differentOddEven: false,
                     scaleWithDoc: false,
-                    firstHeader: "&LFirstHeader",
-                    oddHeader: "&LLeftHeader&CCenterHeader&RRightHeader",
-                    oddFooter: "&LLeftFooter&CCenterFooter&RRightFooter"
+                    firstHeader: new XlsxHeaderFooterText($"{XlsxHeaderFooter.Bold}FirstHeader"),
+                    oddHeader: new XlsxHeaderFooterText(
+                        $"{XlsxHeaderFooter.Bold}LeftHeader", 
+                        $"{XlsxHeaderFooter.Underline}CenterHeader", 
+                        $"{XlsxHeaderFooter.Strikethrough}RightHeader"),
+                    oddFooter: new XlsxHeaderFooterText("LeftFooter", "CenterFooter", "RightFooter")
                     );
             xlsxWriter
                 .BeginWorksheet("HeaderFooterTest")
@@ -476,9 +479,9 @@ public static class XlsxWriterTest
             sheet.HeaderFooter.differentFirst.Should().BeTrue();
             sheet.HeaderFooter.differentOddEven.Should().BeFalse();
             sheet.HeaderFooter.ScaleWithDocument.Should().BeFalse();
-            sheet.HeaderFooter.OddHeader.LeftAlignedText.Should().Be("LeftHeader");
-            sheet.HeaderFooter.OddHeader.CenteredText.Should().Be("CenterHeader");
-            sheet.HeaderFooter.OddHeader.RightAlignedText.Should().Be("RightHeader");
+            sheet.HeaderFooter.OddHeader.LeftAlignedText.Should().Be("&BLeftHeader");
+            sheet.HeaderFooter.OddHeader.CenteredText.Should().Be("&UCenterHeader");
+            sheet.HeaderFooter.OddHeader.RightAlignedText.Should().Be("&SRightHeader");
             sheet.HeaderFooter.OddFooter.LeftAlignedText.Should().Be("LeftFooter");
             sheet.HeaderFooter.OddFooter.CenteredText.Should().Be("CenterFooter");
             sheet.HeaderFooter.OddFooter.RightAlignedText.Should().Be("RightFooter");

--- a/tests/LargeXlsx.Tests/XlsxWriterTest.cs
+++ b/tests/LargeXlsx.Tests/XlsxWriterTest.cs
@@ -457,10 +457,12 @@ public static class XlsxWriterTest
             var headerFooter = 
                 new XlsxHeaderFooter(
                     alignWithMargins: true,
-                    differentFirst: false,
+                    differentFirst: true,
                     differentOddEven: false,
                     scaleWithDoc: false,
-                    evenHeader: "&LLeftHeader&CCenterHeader&RRightHeader"
+                    firstHeader: "&LFirstHeader",
+                    oddHeader: "&LLeftHeader&CCenterHeader&RRightHeader",
+                    oddFooter: "&LLeftFooter&CCenterFooter&RRightFooter"
                     );
             xlsxWriter
                 .BeginWorksheet("HeaderFooterTest")
@@ -471,12 +473,15 @@ public static class XlsxWriterTest
         {
             var sheet = package.Workbook.Worksheets[0];
             sheet.HeaderFooter.AlignWithMargins.Should().BeTrue();
-            sheet.HeaderFooter.differentFirst.Should().BeFalse();
+            sheet.HeaderFooter.differentFirst.Should().BeTrue();
             sheet.HeaderFooter.differentOddEven.Should().BeFalse();
             sheet.HeaderFooter.ScaleWithDocument.Should().BeFalse();
-            sheet.HeaderFooter.EvenHeader.LeftAlignedText.Should().Be("LeftHeader");
-            sheet.HeaderFooter.EvenHeader.CenteredText.Should().Be("CenterHeader");
-            sheet.HeaderFooter.EvenHeader.RightAlignedText.Should().Be("RightHeader");
+            sheet.HeaderFooter.OddHeader.LeftAlignedText.Should().Be("LeftHeader");
+            sheet.HeaderFooter.OddHeader.CenteredText.Should().Be("CenterHeader");
+            sheet.HeaderFooter.OddHeader.RightAlignedText.Should().Be("RightHeader");
+            sheet.HeaderFooter.OddFooter.LeftAlignedText.Should().Be("LeftFooter");
+            sheet.HeaderFooter.OddFooter.CenteredText.Should().Be("CenterFooter");
+            sheet.HeaderFooter.OddFooter.RightAlignedText.Should().Be("RightFooter");
         }
     }
 }


### PR DESCRIPTION
I have added very functionality to write headers and footers to excel sheets.

Usage can be seen in the [HeaderFooter test case](https://github.com/salvois/LargeXlsx/compare/master...soend:LargeXlsx:master?expand=1#diff-9d2ea719e3d46921c71244110457264900636c0054344bde8698d3975600e58aR452) what i have added.

In current implementation person writing the code to add header/footer needs to know the formatting codes when creating the header/footer string. For example `&RSomeTextHere` - where `&R` code specifies the beginning of the right section. More information about the codes can be found in the links below.

When adding headers/footers its important to remember `oddHeader` and `oddFooter` are the main fields to fill. Only when using different odd even headers footers (`differentOddEven: true`) you would fill `evenHeader` or `evenFooter`.

If there is more tests needed or any other change please let me know and i will do them.

Some links to get more information about headerFooter:
[OpenXML HeaderFooter class definition and description of available attributes](https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.spreadsheet.headerfooter?view=openxml-2.8.1)
[Description of formatting codes what can be used in header and footer ](https://learn.microsoft.com/en-us/openspecs/office_standards/ms-oi29500/c167a243-45ad-4def-816e-7032fb1adf5c)
[Another good table about codes to use in header and footer from DevExpress](https://docs.devexpress.com/OfficeFileAPI/114661/excel-export-library/printing/how-to-add-headers-and-footers-to-a-worksheet-printout#header-and-footer-codes)