### PR TITLE
Replace SharpCompress with System.IO.Compression

### DIFF
--- a/examples/Examples/Large.cs
+++ b/examples/Examples/Large.cs
@@ -28,8 +28,8 @@ using System;
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
+using System.IO.Compression;
 using LargeXlsx;
-using SharpCompress.Compressors.Deflate;
 
 namespace Examples;
 
@@ -54,7 +54,7 @@ public static class Large
     private static void DoRun(bool requireCellReferences)
     {
         using var stream = new FileStream($"{nameof(Large)}.xlsx", FileMode.Create, FileAccess.Write);
-        using var xlsxWriter = new XlsxWriter(stream, compressionLevel: CompressionLevel.Level3, requireCellReferences: requireCellReferences);
+        using var xlsxWriter = new XlsxWriter(stream, compressionLevel: CompressionLevel.Optimal, requireCellReferences: requireCellReferences);
         var whiteFont = new XlsxFont("Calibri", 11, Color.White, bold: true);
         var blueFill = new XlsxFill(Color.FromArgb(0, 0x45, 0x86));
         var headerStyle = new XlsxStyle(whiteFont, blueFill, XlsxBorder.None, XlsxNumberFormat.General, XlsxAlignment.Default);

--- a/examples/Examples/StyledLarge.cs
+++ b/examples/Examples/StyledLarge.cs
@@ -28,9 +28,9 @@ using System;
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using LargeXlsx;
-using SharpCompress.Compressors.Deflate;
 
 namespace Examples;
 
@@ -57,7 +57,7 @@ public static class StyledLarge
     {
         var rnd = new Random();
         using var stream = new FileStream($"{nameof(StyledLarge)}.xlsx", FileMode.Create, FileAccess.Write);
-        using var xlsxWriter = new XlsxWriter(stream, compressionLevel: CompressionLevel.Level3, requireCellReferences: requireCellReferences);
+        using var xlsxWriter = new XlsxWriter(stream, compressionLevel: CompressionLevel.Optimal, requireCellReferences: requireCellReferences);
         var headerStyle = new XlsxStyle(
             new XlsxFont("Calibri", 11, Color.White, bold: true),
             new XlsxFill(Color.FromArgb(0, 0x45, 0x86)),

--- a/examples/Examples/Zip64Huge.cs
+++ b/examples/Examples/Zip64Huge.cs
@@ -27,8 +27,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.IO.Compression;
 using LargeXlsx;
-using SharpCompress.Compressors.Deflate;
 
 namespace Examples;
 
@@ -41,7 +41,7 @@ public static class Zip64Huge
     {
         var stopwatch = Stopwatch.StartNew();
         using (var stream = new FileStream($"{nameof(Zip64Huge)}.xlsx", FileMode.Create, FileAccess.Write))
-        using (var xlsxWriter = new XlsxWriter(stream, compressionLevel: CompressionLevel.BestSpeed, useZip64: true))
+        using (var xlsxWriter = new XlsxWriter(stream, compressionLevel: CompressionLevel.Fastest, useZip64: true))
         {
             xlsxWriter.BeginWorksheet("Sheet1", 1, 1);
             xlsxWriter.BeginRow();

--- a/examples/Examples/Zip64Small.cs
+++ b/examples/Examples/Zip64Small.cs
@@ -25,8 +25,8 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 using System.IO;
+using System.IO.Compression;
 using LargeXlsx;
-using SharpCompress.Compressors.Deflate;
 
 namespace Examples;
 
@@ -35,7 +35,7 @@ public static class Zip64Small
     public static void Run()
     {
         using var stream = new FileStream($"{nameof(Zip64Small)}.xlsx", FileMode.Create, FileAccess.Write);
-        using var xlsxWriter = new XlsxWriter(stream, compressionLevel: CompressionLevel.BestSpeed, useZip64: true);
+        using var xlsxWriter = new XlsxWriter(stream, compressionLevel: CompressionLevel.Fastest, useZip64: true);
         xlsxWriter.BeginWorksheet("Sheet1").BeginRow().Write("A1").Write("B1").BeginRow().Write("A2").Write("B2");
     }
 }

--- a/src/LargeXlsx/LargeXlsx.csproj
+++ b/src/LargeXlsx/LargeXlsx.csproj
@@ -12,7 +12,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SharpCompress" Version="0.36.0" />
     <None Include="../../LICENSE.txt" Pack="true" PackagePath="$(PackageLicenseFile)" />
   </ItemGroup>
 

--- a/src/LargeXlsx/SharedStringTable.cs
+++ b/src/LargeXlsx/SharedStringTable.cs
@@ -26,19 +26,21 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Text;
-using SharpCompress.Writers.Zip;
 
 namespace LargeXlsx
 {
     internal class SharedStringTable
     {
         private readonly Dictionary<string, int> _stringItems;
+        private readonly CompressionLevel _compressionLevel;
         private int _nextStringId;
 
-        public SharedStringTable()
+        public SharedStringTable(CompressionLevel compressionLevel = CompressionLevel.Fastest)
         {
+            _compressionLevel = compressionLevel;
             _stringItems = new Dictionary<string, int>();
             _nextStringId = 0;
         }
@@ -53,9 +55,10 @@ namespace LargeXlsx
             return id;
         }
 
-        public void Save(ZipWriter zipWriter)
+        public void Save(ZipArchive zipArchive)
         {
-            using (var stream = zipWriter.WriteToStream("xl/sharedStrings.xml", new ZipWriterEntryOptions()))
+            var entry = zipArchive.CreateEntry("xl/sharedStrings.xml", _compressionLevel);
+            using (var stream = entry.Open())
             using (var streamWriter = new StreamWriter(stream, Encoding.UTF8))
             {
                 streamWriter.WriteLine("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"

--- a/src/LargeXlsx/Stylesheet.cs
+++ b/src/LargeXlsx/Stylesheet.cs
@@ -27,8 +27,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
-using SharpCompress.Writers.Zip;
 
 namespace LargeXlsx
 {
@@ -46,6 +46,7 @@ namespace LargeXlsx
         private readonly Dictionary<XlsxBorder, int> _borders;
         private readonly Dictionary<XlsxNumberFormat, int> _numberFormats;
         private readonly Dictionary<XlsxStyle, int> _styles;
+        private readonly CompressionLevel _compressionLevel;
         private int _nextFontId;
         private int _nextBorderId;
         private int _nextFillId;
@@ -54,8 +55,9 @@ namespace LargeXlsx
         private XlsxStyle _lastUsedStyle;
         private int _lastUsedStyleId;
 
-        public Stylesheet()
+        public Stylesheet(CompressionLevel compressionLevel = CompressionLevel.Fastest)
         {
+            _compressionLevel = compressionLevel;
             _fonts = new Dictionary<XlsxFont, int> { [XlsxFont.Default] = 0 };
             _nextFontId = 1;
 
@@ -108,9 +110,10 @@ namespace LargeXlsx
             return id;
         }
 
-        public void Save(ZipWriter zipWriter)
+        public void Save(ZipArchive zipArchive)
         {
-            using (var stream = zipWriter.WriteToStream("xl/styles.xml", new ZipWriterEntryOptions()))
+            var entry = zipArchive.CreateEntry("xl/styles.xml", _compressionLevel);
+            using (var stream = entry.Open())
             using (var streamWriter = new InvariantCultureStreamWriter(stream))
             {
                 streamWriter.WriteLine("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"

--- a/src/LargeXlsx/Worksheet.cs
+++ b/src/LargeXlsx/Worksheet.cs
@@ -28,8 +28,8 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
-using SharpCompress.Writers.Zip;
 
 namespace LargeXlsx
 {
@@ -57,7 +57,7 @@ namespace LargeXlsx
         public int CurrentColumnNumber { get; private set; }
         internal string AutoFilterAbsoluteRef => _autoFilterAbsoluteRef;
 
-        public Worksheet(ZipWriter zipWriter, int id, string name, int splitRow, int splitColumn, bool rightToLeft, Stylesheet stylesheet, SharedStringTable sharedStringTable, IEnumerable<XlsxColumn> columns, bool showGridLines, bool showHeaders, bool requireCellReferences)
+        public Worksheet(ZipArchive zipArchive, int id, string name, int splitRow, int splitColumn, bool rightToLeft, Stylesheet stylesheet, SharedStringTable sharedStringTable, IEnumerable<XlsxColumn> columns, bool showGridLines, bool showHeaders, bool requireCellReferences, CompressionLevel compressionLevel)
         {
             Id = id;
             Name = name;
@@ -68,7 +68,7 @@ namespace LargeXlsx
             _requireCellReferences = requireCellReferences;
             _mergedCellRefs = new List<string>();
             _cellRefsByDataValidation = new Dictionary<XlsxDataValidation, List<string>>();
-            _stream = zipWriter.WriteToStream($"xl/worksheets/sheet{id}.xml", new ZipWriterEntryOptions());
+            _stream = zipArchive.CreateEntry($"xl/worksheets/sheet{id}.xml", compressionLevel).Open();
             _streamWriter = new InvariantCultureStreamWriter(_stream);
 
             _streamWriter.Write("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"

--- a/src/LargeXlsx/Worksheet.cs
+++ b/src/LargeXlsx/Worksheet.cs
@@ -173,6 +173,32 @@ namespace LargeXlsx
             CurrentColumnNumber++;
         }
 
+        public void Write(long value, XlsxStyle style)
+        {
+            EnsureRow();
+            // <c r="{0}{1}" s="{2}"><v>{3}</v></c>
+            _streamWriter.Write("<c");
+            WriteCellRef();
+            WriteStyle(style);
+            _streamWriter.Write("><v>");
+            _streamWriter.Write(value);
+            _streamWriter.Write("</v></c>\n");
+            CurrentColumnNumber++;
+        }
+
+        public void Write(decimal value, XlsxStyle style)
+        {
+            EnsureRow();
+            // <c r="{0}{1}" s="{2}"><v>{3}</v></c>
+            _streamWriter.Write("<c");
+            WriteCellRef();
+            WriteStyle(style);
+            _streamWriter.Write("><v>");
+            _streamWriter.Write(value);
+            _streamWriter.Write("</v></c>\n");
+            CurrentColumnNumber++;
+        }
+
         public void Write(double value, XlsxStyle style)
         {
             EnsureRow();

--- a/src/LargeXlsx/XlsxColumn.cs
+++ b/src/LargeXlsx/XlsxColumn.cs
@@ -38,6 +38,11 @@ namespace LargeXlsx
             return new XlsxColumn(count, false, null, null);
         }
 
+        public static XlsxColumn NumberFormat(XlsxNumberFormat numberFormat)
+        {
+            return new XlsxColumn(1, false, XlsxStyle.Default.With(numberFormat), null);
+        }
+
         public static XlsxColumn Formatted(double width, int count = 1, bool hidden = false, XlsxStyle style = null)
         {
             return new XlsxColumn(count, hidden, style, width);

--- a/src/LargeXlsx/XlsxWriter.cs
+++ b/src/LargeXlsx/XlsxWriter.cs
@@ -263,14 +263,33 @@ namespace LargeXlsx
             return AddMergedCell(1, columnSpan).Write(value, style, 1).Write(style, repeatCount: columnSpan - 1);
         }
 
+        public XlsxWriter Write(long value, XlsxStyle style = null, int columnSpan = 1)
+        {
+            if (columnSpan == 1)
+            {
+                CheckInWorksheet();
+                _currentWorksheet.Write(value, style ?? DefaultStyle);
+                return this;
+            }
+
+            return AddMergedCell(1, columnSpan).Write(value, style, 1).Write(style, repeatCount: columnSpan - 1);
+        }
+
         public XlsxWriter Write(decimal value, XlsxStyle style = null, int columnSpan = 1)
         {
-            return Write((double)value, style, columnSpan);
+            if (columnSpan == 1)
+            {
+                CheckInWorksheet();
+                _currentWorksheet.Write(value, style ?? DefaultStyle);
+                return this;
+            }
+
+            return AddMergedCell(1, columnSpan).Write(value, style, 1).Write(style, repeatCount: columnSpan - 1);
         }
 
         public XlsxWriter Write(int value, XlsxStyle style = null, int columnSpan = 1)
         {
-            return Write((double)value, style, columnSpan);
+            return Write((long)value, style, columnSpan);
         }
 
         public XlsxWriter Write(DateTime value, XlsxStyle style = null, int columnSpan = 1)


### PR DESCRIPTION
This PR removes the [SharpCompress](https://www.nuget.org/packages/sharpcompress/) dependency, relying instead on [System.IO.Compression](https://learn.microsoft.com/en-us/dotnet/api/system.io.compression?view=net-8.0). With this change, LargerXlsx will no longer have any dependencies outside of .NET.