### PR TITLE
small object heap contention

### DIFF
--- a/src/LargeXlsx/RowNumberStringCache.cs
+++ b/src/LargeXlsx/RowNumberStringCache.cs
@@ -1,0 +1,38 @@
+﻿namespace LargeXlsx
+{
+    /// <summary>
+    /// Caches a single row number string. Used to provide the CurrentRowNumber
+    /// in string form during worksheet production where rows are processed
+    /// consecutively and multiple columns generate string representations of the
+    /// current row. Reduces small object heap allocations by a couple of GB in the
+    /// Examples suite.
+    /// </summary>
+    internal sealed class RowNumberStringCache
+    {
+        private int _rowNumber;
+        private string _rowNumberAsString;
+
+        static RowNumberStringCache()
+        {
+        }
+
+        private RowNumberStringCache()
+        {
+        }
+
+        public static RowNumberStringCache Instance { get; } = new RowNumberStringCache();
+
+        public string GetRowNumberAsString(int rowNumber)
+        {
+            if (_rowNumber == rowNumber)
+            {
+                return _rowNumberAsString;
+            }
+
+            _rowNumber = rowNumber;
+            _rowNumberAsString = rowNumber.ToString();
+
+            return _rowNumberAsString;
+        }
+    }
+}

--- a/src/LargeXlsx/Worksheet.cs
+++ b/src/LargeXlsx/Worksheet.cs
@@ -110,7 +110,7 @@ namespace LargeXlsx
             if (_requireCellReferences || _needsRef)
             {
                 _streamWriter.Write(" r=\"");
-                _streamWriter.Write(CurrentRowNumber);
+                _streamWriter.Write(RowNumberStringCache.Instance.GetRowNumberAsString(CurrentRowNumber));
                 _streamWriter.Write("\"");
                 _needsRef = false;
             }
@@ -286,7 +286,7 @@ namespace LargeXlsx
             {
                 _streamWriter.Write(" r=\"");
                 _streamWriter.Write(Util.GetColumnName(CurrentColumnNumber));
-                _streamWriter.Write(CurrentRowNumber);
+                _streamWriter.Write(RowNumberStringCache.Instance.GetRowNumberAsString(CurrentRowNumber));
                 _streamWriter.Write("\"");
                 _needsRef = false;
             }


### PR DESCRIPTION
Caches a single row number as a string. Used to provide the CurrentRowNumber in string form during worksheet production where rows are processed consecutively and multiple columns generate string representations of the current row. Reduces small object heap allocations by a couple of GB in the Examples suite.

Minor mod. Consider whether the improvement in memory usage is significant enough to warrant.