### PR TITLE
Add support for row grouping and collapsed state in BeginRow

### DIFF
--- a/Examples/Grouping.cs
+++ b/Examples/Grouping.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 LargeXlsx - Minimalistic .net library to write large XLSX files
 
 Copyright 2020-2025 Salvatore ISAJA. All rights reserved.
@@ -24,37 +24,23 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
-using System;
+using System.IO;
+using LargeXlsx;
 
 namespace Examples;
 
-public static class Program
+public static class Grouping
 {
-    public static void Main(string[] _)
+    public static void Run()
     {
-        Simple.Run();
-        MultipleSheet.Run();
-        FrozenPanes.Run();
-        HideGridlines.Run();
-        WorksheetVisibility.Run();
-        NumberFormats.Run();
-        ColumnFormatting.Run();
-        RowFormatting.Run();
-        Alignment.Run();
-        Border.Run();
-        DataValidation.Run();
-        RightToLeft.Run();
-        Zip64Small.Run();
-        SheetProtection.Run();
-        HeaderFooterPageBreaks.Run();
-        InvalidXmlChars.Run();
-        InlineStrings.Run();
-        SharedStrings.Run();
-        Large.Run();
-        StyledLarge.Run();
-        StyledLargeCreateStyles.Run();
-        Zip64Huge.Run();
-        Grouping.Run();
-        Console.WriteLine($"Gen0: {GC.CollectionCount(0)} Gen1: {GC.CollectionCount(1)} Gen2: {GC.CollectionCount(2)} TotalAllocatedBytes: {GC.GetTotalAllocatedBytes()}");
+        using var stream = new FileStream($"{nameof(Grouping)}.xlsx", FileMode.Create, FileAccess.Write);
+        using var xlsxWriter = new XlsxWriter(stream);
+
+        xlsxWriter
+            .BeginWorksheet("Sheet 1")
+            .BeginRow().Write("Header 1").Write("Header 2").Write("Header 3")
+            .BeginRow(groupLevel: 1).Write("Test 1").Write("Test 2").Write("Test 3")
+            .BeginRow(groupLevel: 1).Write("Test 4").Write("Test 5").Write("Test 6");
+
     }
 }

--- a/LargeXlsx/Worksheet.cs
+++ b/LargeXlsx/Worksheet.cs
@@ -119,7 +119,7 @@ namespace LargeXlsx
             _stream.Dispose();
         }
 
-        public void BeginRow(double? height, bool hidden, XlsxStyle style)
+        public void BeginRow(double? height, bool hidden, XlsxStyle style, bool collapsed, int? groupLevel)
         {
             CloseLastRow();
             if (CurrentRowNumber == Limits.MaxRowCount)
@@ -135,6 +135,10 @@ namespace LargeXlsx
                 _streamWriter.Write("\"");
                 _needsRef = false;
             }
+            if (collapsed)
+                _streamWriter.Write(" collapsed=\"1\"");
+            if (groupLevel != null)
+                _streamWriter.Write(" outlineLevel=\"{0}\"", groupLevel);
             if (height.HasValue)
                 _streamWriter.Write(" ht=\"{0}\" customHeight=\"1\"", height);
             if (hidden)

--- a/LargeXlsx/XlsxWriter.cs
+++ b/LargeXlsx/XlsxWriter.cs
@@ -248,10 +248,10 @@ namespace LargeXlsx
             return this;
         }
 
-        public XlsxWriter BeginRow(double? height = null, bool hidden = false, XlsxStyle style = null)
+        public XlsxWriter BeginRow(double? height = null, bool hidden = false, XlsxStyle style = null, bool collapsed = false, int? groupLevel = null)
         {
             CheckInWorksheet();
-            _currentWorksheet.BeginRow(height, hidden, style);
+            _currentWorksheet.BeginRow(height, hidden, style, collapsed, groupLevel);
             return this;
         }
 


### PR DESCRIPTION
This update adds support for Excel row grouping by introducing two new optional parameters to BeginRow:
`collapsed` — whether the row group should be collapsed by default
`groupLevel` — the outline level for grouping

I'm not completely sure about adding collapsed and groupLevel directly to BeginRow. It works, but it feels a bit awkward to keep extending this method with more parameters. Open to suggestions if there's a better place or pattern for this.
