### PR TITLE
Replace SharpCompress with System.IO.Compression 

### DIFF
--- a/Examples/Large.cs
+++ b/Examples/Large.cs
@@ -28,8 +28,8 @@ using System;
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
+using System.IO.Compression;
 using LargeXlsx;
-using SharpCompress.Compressors.Deflate;
 
 namespace Examples;
 
@@ -54,7 +54,7 @@ public static class Large
     private static void DoRun(bool requireCellReferences)
     {
         using var stream = new FileStream($"{nameof(Large)}_{requireCellReferences}.xlsx", FileMode.Create, FileAccess.Write);
-        using var xlsxWriter = new XlsxWriter(stream, compressionLevel: CompressionLevel.Level3, requireCellReferences: requireCellReferences);
+        using var xlsxWriter = new XlsxWriter(stream, compressionLevel: CompressionLevel.Fastest, requireCellReferences: requireCellReferences);
         var whiteFont = new XlsxFont("Calibri", 11, Color.White, bold: true);
         var blueFill = new XlsxFill(Color.FromArgb(0, 0x45, 0x86));
         var headerStyle = new XlsxStyle(whiteFont, blueFill, XlsxBorder.None, XlsxNumberFormat.General, XlsxAlignment.Default);

--- a/Examples/StyledLarge.cs
+++ b/Examples/StyledLarge.cs
@@ -28,9 +28,9 @@ using System;
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using LargeXlsx;
-using SharpCompress.Compressors.Deflate;
 
 namespace Examples;
 
@@ -57,7 +57,7 @@ public static class StyledLarge
     {
         var rnd = new Random();
         using var stream = new FileStream($"{nameof(StyledLarge)}_{requireCellReferences}.xlsx", FileMode.Create, FileAccess.Write);
-        using var xlsxWriter = new XlsxWriter(stream, compressionLevel: CompressionLevel.Level3, requireCellReferences: requireCellReferences);
+        using var xlsxWriter = new XlsxWriter(stream, compressionLevel: CompressionLevel.Fastest, requireCellReferences: requireCellReferences);
         var headerStyle = new XlsxStyle(
             new XlsxFont("Calibri", 11, Color.White, bold: true),
             new XlsxFill(Color.FromArgb(0, 0x45, 0x86)),

--- a/Examples/StyledLargeCreateStyles.cs
+++ b/Examples/StyledLargeCreateStyles.cs
@@ -28,6 +28,7 @@ using System;
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using LargeXlsx;
 
@@ -56,7 +57,7 @@ public static class StyledLargeCreateStyles
     {
         var rnd = new Random();
         using var stream = new FileStream($"{nameof(StyledLargeCreateStyles)}_{requireCellReferences}.xlsx", FileMode.Create, FileAccess.Write);
-        using var xlsxWriter = new XlsxWriter(stream, requireCellReferences: requireCellReferences);
+        using var xlsxWriter = new XlsxWriter(stream, requireCellReferences: requireCellReferences, compressionLevel: CompressionLevel.Fastest);
         var colors = Enumerable.Repeat(0, 100).Select(_ => Color.FromArgb(rnd.Next(256), rnd.Next(256), rnd.Next(256))).ToList();
         var headerStyle = new XlsxStyle(
             new XlsxFont("Calibri", 10.5, Color.White, bold: true),

--- a/Examples/Zip64Huge.cs
+++ b/Examples/Zip64Huge.cs
@@ -27,8 +27,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.IO.Compression;
 using LargeXlsx;
-using SharpCompress.Compressors.Deflate;
 
 namespace Examples;
 
@@ -41,7 +41,7 @@ public static class Zip64Huge
     {
         var stopwatch = Stopwatch.StartNew();
         using (var stream = new FileStream($"{nameof(Zip64Huge)}.xlsx", FileMode.Create, FileAccess.Write))
-        using (var xlsxWriter = new XlsxWriter(stream, compressionLevel: CompressionLevel.BestSpeed, useZip64: true))
+        using (var xlsxWriter = new XlsxWriter(stream, compressionLevel: CompressionLevel.Fastest))
         {
             xlsxWriter.BeginWorksheet("Sheet1", 1, 1);
             xlsxWriter.BeginRow();

--- a/Examples/Zip64Small.cs
+++ b/Examples/Zip64Small.cs
@@ -25,8 +25,8 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 using System.IO;
+using System.IO.Compression;
 using LargeXlsx;
-using SharpCompress.Compressors.Deflate;
 
 namespace Examples;
 
@@ -35,7 +35,7 @@ public static class Zip64Small
     public static void Run()
     {
         using var stream = new FileStream($"{nameof(Zip64Small)}.xlsx", FileMode.Create, FileAccess.Write);
-        using var xlsxWriter = new XlsxWriter(stream, compressionLevel: CompressionLevel.BestSpeed, useZip64: true);
+        using var xlsxWriter = new XlsxWriter(stream, compressionLevel: CompressionLevel.Fastest);
         xlsxWriter.BeginWorksheet("Sheet1").BeginRow().Write("A1").Write("B1").BeginRow().Write("A2").Write("B2");
     }
 }

--- a/LargeXlsx.Tests/XlsxWriterTest.cs
+++ b/LargeXlsx.Tests/XlsxWriterTest.cs
@@ -388,10 +388,10 @@ public static class XlsxWriterTest
     }
 
     [Theory]
-    public static void Zip64(bool useZip64)
+    public static void Zip64()
     {
         using var stream = new MemoryStream();
-        using (var xlsxWriter = new XlsxWriter(stream, useZip64: useZip64))
+        using (var xlsxWriter = new XlsxWriter(stream))
         {
             xlsxWriter
                 .BeginWorksheet("Sheet1")

--- a/LargeXlsx/LargeXlsx.csproj
+++ b/LargeXlsx/LargeXlsx.csproj
@@ -12,7 +12,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SharpCompress" Version="0.39.0" />
     <None Include="../LICENSE.txt" Pack="true" PackagePath="$(PackageLicenseFile)" />
   </ItemGroup>
 

--- a/LargeXlsx/SharedStringTable.cs
+++ b/LargeXlsx/SharedStringTable.cs
@@ -26,9 +26,9 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Text;
-using SharpCompress.Writers.Zip;
 
 namespace LargeXlsx
 {
@@ -55,16 +55,15 @@ namespace LargeXlsx
             return id;
         }
 
-        public void Save(ZipWriter zipWriter)
+        public void Save(ZipArchive zipArchive, CompressionLevel compressionLevel)
         {
-            using (var stream = zipWriter.WriteToStream("xl/sharedStrings.xml", new ZipWriterEntryOptions()))
-            using (var streamWriter = new StreamWriter(stream, Encoding.UTF8))
+            var entry = zipArchive.CreateEntry("xl/sharedStrings.xml", compressionLevel);
+            using (var streamWriter = new StreamWriter(entry.Open(), Encoding.UTF8))
             {
                 streamWriter.WriteLine("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
                                    + "<sst xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\">");
                 foreach (var si in _stringItems.OrderBy(s => s.Value))
                 {
-                    // <si><t xml:space="preserve">{0}</t></si>
                     streamWriter
                         .Append("<si><t")
                         .AddSpacePreserveIfNeeded(si.Key)

--- a/LargeXlsx/Stylesheet.cs
+++ b/LargeXlsx/Stylesheet.cs
@@ -27,8 +27,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
-using SharpCompress.Writers.Zip;
 
 namespace LargeXlsx
 {
@@ -108,10 +108,10 @@ namespace LargeXlsx
             return id;
         }
 
-        public void Save(ZipWriter zipWriter)
+        public void Save(ZipArchive zipArchive, CompressionLevel compressionLevel)
         {
-            using (var stream = zipWriter.WriteToStream("xl/styles.xml", new ZipWriterEntryOptions()))
-            using (var streamWriter = new InvariantCultureStreamWriter(stream))
+            var entry = zipArchive.CreateEntry("xl/styles.xml", compressionLevel);
+            using (var streamWriter = new InvariantCultureStreamWriter(entry.Open()))
             {
                 streamWriter.WriteLine("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
                                    + "<styleSheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\">");

--- a/LargeXlsx/Worksheet.cs
+++ b/LargeXlsx/Worksheet.cs
@@ -28,8 +28,8 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
-using SharpCompress.Writers.Zip;
 
 namespace LargeXlsx
 {
@@ -60,7 +60,8 @@ namespace LargeXlsx
         internal string AutoFilterAbsoluteRef => _autoFilterAbsoluteRef;
 
         public Worksheet(
-            ZipWriter zipWriter,
+            ZipArchive zipArchive,
+            CompressionLevel compressionLevel,
             int id,
             string name,
             int splitRow,
@@ -88,7 +89,8 @@ namespace LargeXlsx
             _pageBreakRowNumbers = new HashSet<int>();
             _pageBreakColumnNumbers = new HashSet<int>();
             _cellRefsByDataValidation = new Dictionary<XlsxDataValidation, List<string>>();
-            _stream = zipWriter.WriteToStream($"xl/worksheets/sheet{id}.xml", new ZipWriterEntryOptions());
+            var entry = zipArchive.CreateEntry($"xl/worksheets/sheet{id}.xml", compressionLevel);
+            _stream = entry.Open();
             _streamWriter = new InvariantCultureStreamWriter(_stream);
 
             _streamWriter.Write("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"


### PR DESCRIPTION
Following up on an idea from @otykier, this PR replaces Sharp.Compress with System.IO.Compression. All tests and examples run (with significant performance gains in my ad-hoc benchmarks). I have also tested that the huge archives can be opened in Excel. There are breaking changes in the XlsxWriter constructor because of the use of a different CompressionLevel enum and dropping the Zip64 flag (which is handled internally by the library). This would also open up the way for an async API at some point.