### PR TITLE
Simple Async API implementation

### DIFF
--- a/LargeXlsx/InvariantCultureStreamWriter.cs
+++ b/LargeXlsx/InvariantCultureStreamWriter.cs
@@ -33,7 +33,12 @@ namespace LargeXlsx
 {
     internal class InvariantCultureStreamWriter : StreamWriter
     {
-        public InvariantCultureStreamWriter(Stream stream) : base(stream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false)) { }
+        public InvariantCultureStreamWriter(Stream stream, int bufferSize = 8192)
+            : base(stream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), bufferSize)
+        {
+            // StreamWriter.AutoFlush is false by default, which is what is needed for performance
+        }
+
         public override IFormatProvider FormatProvider => CultureInfo.InvariantCulture;
     }
 }


### PR DESCRIPTION
XlsxWriter now has a `FlushAsync` method that can be issued by the caller at regular intervals providing better scalability in a server context where threads can be freed up. We can also specify a buffer size in the XlsxWriter ctor (it defaults to 8KB). Note that the stream automatically flushes synchronously when the buffer is full, so effective use of the explicit async flush would mean the caller issuing a flush before the buffer is full, i.e. when using async, we should try to ensure that user-initiated flushes are the main way to control when data is written to the stream.

The Dispose is synchronous and the stream is flushed automatically as before. This solution is simple (simplistic?) and retains the chatty synchronous API (i.e. we don't use WriteAsync).