### PR TITLE
Fix 66

### DIFF
--- a/LargeXlsx/Worksheet.cs
+++ b/LargeXlsx/Worksheet.cs
@@ -204,7 +204,9 @@ namespace LargeXlsx
             _streamWriter.Write("<c");
             WriteCellRef();
             WriteStyle(style);
-            _streamWriter.Append("><v>").Append(value).Append("</v></c>\n");
+            // Normalize -0.0 to 0.0 for Excel compatibility
+            double normalized = value == 0.0 ? 0.0 : value;
+            _streamWriter.Append("><v>").Append(normalized).Append("</v></c>\n");
             CurrentColumnNumber++;
         }
 


### PR DESCRIPTION
Fix for #66 

There are no practical circumstances in Excel or the OpenXML spreadsheet format where storing -0.0 is meaningful or desirable. Excel does not distinguish between 0.0 and -0.0 - it always displays and stores zero as 0, regardless of sign. When you manually enter "-0.0" in Excel, it is stored as "0". The OpenXML specification does not require or support a distinction, and all major spreadsheet applications treat -0.0 as 0.0.

The "normalisation" fix included in the PR is not needed for decimal or integer types.