### PR TITLE
Multi-target tests and Examples

### DIFF
--- a/Examples/Alignment.cs
+++ b/Examples/Alignment.cs
@@ -27,27 +27,42 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 using System.IO;
 using LargeXlsx;
 
-namespace Examples;
-
-public static class Alignment
+namespace Examples
 {
-    public static void Run()
+    public static class Alignment
     {
-        using var stream = new FileStream($"{nameof(Alignment)}.xlsx", FileMode.Create, FileAccess.Write);
-        using var xlsxWriter = new XlsxWriter(stream);
-        xlsxWriter
-            .BeginWorksheet("Sheet 1", columns: new[] { XlsxColumn.Formatted(width: 40) })
-            .BeginRow().Write("Left", XlsxStyle.Default.With(new XlsxAlignment(horizontal: XlsxAlignment.Horizontal.Left)))
-            .BeginRow().Write("Center", XlsxStyle.Default.With(new XlsxAlignment(horizontal: XlsxAlignment.Horizontal.Center)))
-            .BeginRow().Write("Right", XlsxStyle.Default.With(new XlsxAlignment(horizontal: XlsxAlignment.Horizontal.Right)))
-            .BeginRow(height: 30).Write("Top", XlsxStyle.Default.With(new XlsxAlignment(vertical: XlsxAlignment.Vertical.Top)))
-            .BeginRow(height: 30).Write("Middle", XlsxStyle.Default.With(new XlsxAlignment(vertical: XlsxAlignment.Vertical.Center)))
-            .BeginRow(height: 30).Write("Bottom", XlsxStyle.Default.With(new XlsxAlignment(vertical: XlsxAlignment.Vertical.Bottom)))
-            .BeginRow(height: 90).Write("Rotated by 45°", XlsxStyle.Default.With(new XlsxAlignment(textRotation: 45)))
-            .BeginRow(height: 120).Write("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt" +
-                                         " ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation" +
-                                         " ullamco laboris nisi ut aliquip ex ea commodo consequat.",
-                XlsxStyle.Default.With(new XlsxAlignment(horizontal: XlsxAlignment.Horizontal.Justify, vertical: XlsxAlignment.Vertical.Justify, wrapText: true)))
-            .BeginRow().Write("Lorem ipsum dolor sit amet, consectetur adipiscing elit", XlsxStyle.Default.With(new XlsxAlignment(shrinkToFit: true)));
+        public static void Run()
+        {
+            using (var stream = new FileStream($"{nameof(Alignment)}.xlsx", FileMode.Create, FileAccess.Write))
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                {
+                    xlsxWriter
+                        .BeginWorksheet("Sheet 1", columns: new[] {XlsxColumn.Formatted(width: 40)})
+                        .BeginRow().Write("Left",
+                            XlsxStyle.Default.With(new XlsxAlignment(horizontal: XlsxAlignment.Horizontal.Left)))
+                        .BeginRow().Write("Center",
+                            XlsxStyle.Default.With(new XlsxAlignment(horizontal: XlsxAlignment.Horizontal.Center)))
+                        .BeginRow().Write("Right",
+                            XlsxStyle.Default.With(new XlsxAlignment(horizontal: XlsxAlignment.Horizontal.Right)))
+                        .BeginRow(height: 30).Write("Top",
+                            XlsxStyle.Default.With(new XlsxAlignment(vertical: XlsxAlignment.Vertical.Top)))
+                        .BeginRow(height: 30).Write("Middle",
+                            XlsxStyle.Default.With(new XlsxAlignment(vertical: XlsxAlignment.Vertical.Center)))
+                        .BeginRow(height: 30).Write("Bottom",
+                            XlsxStyle.Default.With(new XlsxAlignment(vertical: XlsxAlignment.Vertical.Bottom)))
+                        .BeginRow(height: 90).Write("Rotated by 45°",
+                            XlsxStyle.Default.With(new XlsxAlignment(textRotation: 45)))
+                        .BeginRow(height: 120).Write(
+                            "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt" +
+                            " ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation" +
+                            " ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+                            XlsxStyle.Default.With(new XlsxAlignment(horizontal: XlsxAlignment.Horizontal.Justify,
+                                vertical: XlsxAlignment.Vertical.Justify, wrapText: true)))
+                        .BeginRow().Write("Lorem ipsum dolor sit amet, consectetur adipiscing elit",
+                            XlsxStyle.Default.With(new XlsxAlignment(shrinkToFit: true)));
+                }
+            }
+        }
     }
 }

--- a/Examples/Border.cs
+++ b/Examples/Border.cs
@@ -28,24 +28,39 @@ using System.Drawing;
 using System.IO;
 using LargeXlsx;
 
-namespace Examples;
-
-public static class Border
+namespace Examples
 {
-    public static void Run()
+    public static class Border
     {
-        using var stream = new FileStream($"{nameof(Border)}.xlsx", FileMode.Create, FileAccess.Write);
-        using var xlsxWriter = new XlsxWriter(stream);
-        var leftBorderStyle = XlsxStyle.Default.With(new XlsxBorder(left: new XlsxBorder.Line(Color.DeepPink, XlsxBorder.Style.Thin)));
-        var allBorderStyle = XlsxStyle.Default.With(XlsxBorder.Around(new XlsxBorder.Line(Color.CornflowerBlue, XlsxBorder.Style.Dashed)));
-        var diagonalBorderStyle = XlsxStyle.Default.With(
-            new XlsxBorder(diagonal: new XlsxBorder.Line(Color.Red, XlsxBorder.Style.Dotted), diagonalDown: true, diagonalUp: true));
+        public static void Run()
+        {
+            using (var stream = new FileStream($"{nameof(Border)}.xlsx", FileMode.Create, FileAccess.Write))
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                {
+                    var leftBorderStyle =
+                        XlsxStyle.Default.With(
+                            new XlsxBorder(left: new XlsxBorder.Line(Color.DeepPink, XlsxBorder.Style.Thin)));
+                    var allBorderStyle =
+                        XlsxStyle.Default.With(
+                            XlsxBorder.Around(new XlsxBorder.Line(Color.CornflowerBlue, XlsxBorder.Style.Dashed)));
+                    var diagonalBorderStyle = XlsxStyle.Default.With(
+                        new XlsxBorder(diagonal: new XlsxBorder.Line(Color.Red, XlsxBorder.Style.Dotted),
+                            diagonalDown: true,
+                            diagonalUp: true));
 
-        xlsxWriter
-            .BeginWorksheet("Sheet1")
-            .SkipRows(1)
-            .BeginRow(height: 50).SkipColumns(1).Write("B1", leftBorderStyle).SkipColumns(1).Write("D1", allBorderStyle).Write("E1", diagonalBorderStyle)
-            .BeginRow().SkipColumns(1).Write("B2", leftBorderStyle).SkipColumns(1).Write("D2", allBorderStyle).Write("E2", diagonalBorderStyle)
-            .BeginRow().SkipColumns(1).Write(leftBorderStyle).SkipColumns(1).Write(allBorderStyle).Write(diagonalBorderStyle);
+                    xlsxWriter
+                        .BeginWorksheet("Sheet1")
+                        .SkipRows(1)
+                        .BeginRow(height: 50).SkipColumns(1).Write("B1", leftBorderStyle).SkipColumns(1)
+                        .Write("D1", allBorderStyle).Write("E1", diagonalBorderStyle)
+                        .BeginRow().SkipColumns(1).Write("B2", leftBorderStyle).SkipColumns(1)
+                        .Write("D2", allBorderStyle)
+                        .Write("E2", diagonalBorderStyle)
+                        .BeginRow().SkipColumns(1).Write(leftBorderStyle).SkipColumns(1).Write(allBorderStyle)
+                        .Write(diagonalBorderStyle);
+                }
+            }
+        }
     }
 }

--- a/Examples/ColumnFormatting.cs
+++ b/Examples/ColumnFormatting.cs
@@ -29,30 +29,37 @@ using System.Drawing;
 using System.IO;
 using LargeXlsx;
 
-namespace Examples;
-
-public static class ColumnFormatting
+namespace Examples
 {
-    public static void Run()
+    public static class ColumnFormatting
     {
-        var rnd = new Random();
-        using var stream = new FileStream($"{nameof(ColumnFormatting)}.xlsx", FileMode.Create, FileAccess.Write);
-        using var xlsxWriter = new XlsxWriter(stream);
-        var blueStyle = new XlsxStyle(XlsxFont.Default.With(Color.White), new XlsxFill(Color.FromArgb(0, 0x45, 0x86)), XlsxBorder.None, XlsxNumberFormat.General, XlsxAlignment.Default);
-
-        xlsxWriter
-            .BeginWorksheet("Sheet 1", columns: new[]
-            {
-                XlsxColumn.Formatted(count: 2, width: 20),
-                XlsxColumn.Unformatted(3),
-                XlsxColumn.Formatted(style: blueStyle, width: 9),
-                XlsxColumn.Formatted(hidden: true, width: 0)
-            });
-        for (var i = 0; i < 10; i++)
+        public static void Run()
         {
-            xlsxWriter.BeginRow();
-            for (var j = 0; j < 10; j++)
-                xlsxWriter.Write(rnd.Next());
+            var rnd = new Random();
+            using (var stream = new FileStream($"{nameof(ColumnFormatting)}.xlsx", FileMode.Create, FileAccess.Write))
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                {
+                    var blueStyle = new XlsxStyle(XlsxFont.Default.With(Color.White),
+                        new XlsxFill(Color.FromArgb(0, 0x45, 0x86)), XlsxBorder.None, XlsxNumberFormat.General,
+                        XlsxAlignment.Default);
+
+                    xlsxWriter
+                        .BeginWorksheet("Sheet 1", columns: new[]
+                        {
+                            XlsxColumn.Formatted(count: 2, width: 20),
+                            XlsxColumn.Unformatted(3),
+                            XlsxColumn.Formatted(style: blueStyle, width: 9),
+                            XlsxColumn.Formatted(hidden: true, width: 0)
+                        });
+                    for (var i = 0; i < 10; i++)
+                    {
+                        xlsxWriter.BeginRow();
+                        for (var j = 0; j < 10; j++)
+                            xlsxWriter.Write(rnd.Next());
+                    }
+                }
+            }
         }
     }
 }

--- a/Examples/DataValidation.cs
+++ b/Examples/DataValidation.cs
@@ -29,36 +29,51 @@ using System.Drawing;
 using System.IO;
 using LargeXlsx;
 
-namespace Examples;
-
-public static class DataValidation
+namespace Examples
 {
-    public static void Run()
+    public static class DataValidation
     {
-        using var stream = new FileStream($"{nameof(DataValidation)}.xlsx", FileMode.Create, FileAccess.Write);
-        using var xlsxWriter = new XlsxWriter(stream);
-        xlsxWriter.BeginWorksheet("Sheet 1")
-            .BeginRow()
-            .AddDataValidation(new XlsxDataValidation(validationType: XlsxDataValidation.ValidationType.List, formula1: "\"Lorem,Ipsum,Dolor\""))
-            .Write(XlsxStyle.Default.With(new XlsxFill(Color.OldLace)))
-            .SkipColumns(1)
-            .AddDataValidation(1, 2, new XlsxDataValidation(validationType: XlsxDataValidation.ValidationType.List, formula1: "\"Lorem,Ipsum,Dolor\""))
-            .Write(XlsxStyle.Default.With(new XlsxFill(Color.OldLace)), repeatCount: 2)
-            .BeginRow()
-            .AddDataValidation(XlsxDataValidation.List(new[] { "Lorem", "Ipsum", "Dolor" }))
-            .Write(XlsxStyle.Default.With(new XlsxFill(Color.OldLace)))
-            .BeginRow()
-            .AddDataValidation(XlsxDataValidation.List(new[] { "1", "3.141592", "Sit" },
-                showErrorMessage: true, showInputMessage: true, errorStyle: XlsxDataValidation.ErrorStyle.Warning))
-            .Write(XlsxStyle.Default.With(new XlsxFill(Color.AliceBlue)))
-            .BeginRow()
-            .AddDataValidation(XlsxDataValidation.List(new[] { "1", "\"2\"", "\"3.141592\"", "\"3,141592\"", "3,,141592", "\"Sit, Amet\"" },
-                showErrorMessage: true, showInputMessage: true, errorTitle: "Error title", error: "A very informative error message",
-                promptTitle: "Prompt title", prompt: "A very enlightening prompt"))
-            .Write(XlsxStyle.Default.With(new XlsxFill(Color.BlueViolet)))
-            .BeginRow()
-            .AddDataValidation(new XlsxDataValidation(validationType: XlsxDataValidation.ValidationType.List, formula1: "=Choices!A1:A3"))
-            .Write(XlsxStyle.Default.With(new XlsxFill(Color.PaleGreen)))
-            .BeginWorksheet("Choices").BeginRow().Write(3.141592).BeginRow().Write("Lorem").BeginRow().Write("Ipsum, Dolor");
+        public static void Run()
+        {
+            using (var stream = new FileStream($"{nameof(DataValidation)}.xlsx", FileMode.Create, FileAccess.Write))
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                {
+                    xlsxWriter.BeginWorksheet("Sheet 1")
+                        .BeginRow()
+                        .AddDataValidation(new XlsxDataValidation(
+                            validationType: XlsxDataValidation.ValidationType.List,
+                            formula1: "\"Lorem,Ipsum,Dolor\""))
+                        .Write(XlsxStyle.Default.With(new XlsxFill(Color.OldLace)))
+                        .SkipColumns(1)
+                        .AddDataValidation(1, 2,
+                            new XlsxDataValidation(validationType: XlsxDataValidation.ValidationType.List,
+                                formula1: "\"Lorem,Ipsum,Dolor\""))
+                        .Write(XlsxStyle.Default.With(new XlsxFill(Color.OldLace)), repeatCount: 2)
+                        .BeginRow()
+                        .AddDataValidation(XlsxDataValidation.List(new[] {"Lorem", "Ipsum", "Dolor"}))
+                        .Write(XlsxStyle.Default.With(new XlsxFill(Color.OldLace)))
+                        .BeginRow()
+                        .AddDataValidation(XlsxDataValidation.List(new[] {"1", "3.141592", "Sit"},
+                            showErrorMessage: true, showInputMessage: true,
+                            errorStyle: XlsxDataValidation.ErrorStyle.Warning))
+                        .Write(XlsxStyle.Default.With(new XlsxFill(Color.AliceBlue)))
+                        .BeginRow()
+                        .AddDataValidation(XlsxDataValidation.List(
+                            new[] {"1", "\"2\"", "\"3.141592\"", "\"3,141592\"", "3,,141592", "\"Sit, Amet\""},
+                            showErrorMessage: true, showInputMessage: true, errorTitle: "Error title",
+                            error: "A very informative error message",
+                            promptTitle: "Prompt title", prompt: "A very enlightening prompt"))
+                        .Write(XlsxStyle.Default.With(new XlsxFill(Color.BlueViolet)))
+                        .BeginRow()
+                        .AddDataValidation(new XlsxDataValidation(
+                            validationType: XlsxDataValidation.ValidationType.List,
+                            formula1: "=Choices!A1:A3"))
+                        .Write(XlsxStyle.Default.With(new XlsxFill(Color.PaleGreen)))
+                        .BeginWorksheet("Choices").BeginRow().Write(3.141592).BeginRow().Write("Lorem").BeginRow()
+                        .Write("Ipsum, Dolor");
+                }
+            }
+        }
     }
 }

--- a/Examples/Examples.csproj
+++ b/Examples/Examples.csproj
@@ -1,14 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <WarningsAsErrors>Nullable</WarningsAsErrors>
-  </PropertyGroup>
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFrameworks>net48;net6.0;net8.0</TargetFrameworks>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\LargeXlsx\LargeXlsx.csproj" />
-  </ItemGroup>
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net8.0'">
+		<!-- Settings for .NET 6 or 8 -->
+		<Nullable>enable</Nullable>
+		<WarningsAsErrors>Nullable</WarningsAsErrors>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\LargeXlsx\LargeXlsx.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/Examples/FrozenPanes.cs
+++ b/Examples/FrozenPanes.cs
@@ -27,26 +27,31 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 using System.IO;
 using LargeXlsx;
 
-namespace Examples;
-
-public static class FrozenPanes
+namespace Examples
 {
-    public static void Run()
+    public static class FrozenPanes
     {
-        using var stream = new FileStream($"{nameof(FrozenPanes)}.xlsx", FileMode.Create, FileAccess.Write);
-        using var xlsxWriter = new XlsxWriter(stream);
-        xlsxWriter
-            .BeginWorksheet("SplitRow", splitRow: 1)
-            .BeginRow().Write("A1").Write("B1").Write("C1")
-            .BeginRow().Write("A2").Write("B2").Write("C2")
-            .BeginRow().Write("A3").Write("B3").Write("C3")
-            .BeginWorksheet("SplitColumn", splitColumn: 1)
-            .BeginRow().Write("A1").Write("B1").Write("C1")
-            .BeginRow().Write("A2").Write("B2").Write("C2")
-            .BeginRow().Write("A3").Write("B3").Write("C3")
-            .BeginWorksheet("SplitBoth", splitRow: 10, splitColumn: 20)
-            .BeginRow().Write("A1").Write("B1").Write("C1")
-            .BeginRow().Write("A2").Write("B2").Write("C2")
-            .BeginRow().Write("A3").Write("B3").Write("C3");
+        public static void Run()
+        {
+            using (var stream = new FileStream($"{nameof(FrozenPanes)}.xlsx", FileMode.Create, FileAccess.Write))
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                {
+                    xlsxWriter
+                        .BeginWorksheet("SplitRow", splitRow: 1)
+                        .BeginRow().Write("A1").Write("B1").Write("C1")
+                        .BeginRow().Write("A2").Write("B2").Write("C2")
+                        .BeginRow().Write("A3").Write("B3").Write("C3")
+                        .BeginWorksheet("SplitColumn", splitColumn: 1)
+                        .BeginRow().Write("A1").Write("B1").Write("C1")
+                        .BeginRow().Write("A2").Write("B2").Write("C2")
+                        .BeginRow().Write("A3").Write("B3").Write("C3")
+                        .BeginWorksheet("SplitBoth", splitRow: 10, splitColumn: 20)
+                        .BeginRow().Write("A1").Write("B1").Write("C1")
+                        .BeginRow().Write("A2").Write("B2").Write("C2")
+                        .BeginRow().Write("A3").Write("B3").Write("C3");
+                }
+            }
+        }
     }
 }

--- a/Examples/HeaderFooterPageBreaks.cs
+++ b/Examples/HeaderFooterPageBreaks.cs
@@ -1,30 +1,35 @@
 ﻿using System.IO;
 using LargeXlsx;
 
-namespace Examples;
-
-public static class HeaderFooterPageBreaks
+namespace Examples
 {
-    public static void Run()
+    public static class HeaderFooterPageBreaks
     {
-        using var stream = new FileStream($"{nameof(HeaderFooterPageBreaks)}.xlsx", FileMode.Create, FileAccess.Write);
-        using var xlsxWriter = new XlsxWriter(stream);
+        public static void Run()
+        {
+            using (var stream = new FileStream($"{nameof(HeaderFooterPageBreaks)}.xlsx", FileMode.Create,
+                       FileAccess.Write))
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                {
+                    var headerFooter = new XlsxHeaderFooter(
+                        oddHeader: new XlsxHeaderFooterBuilder()
+                            .Left().Bold().Text(nameof(HeaderFooterPageBreaks)).Bold().Text(" example")
+                            .ToString(),
+                        oddFooter: new XlsxHeaderFooterBuilder()
+                            .Left().Text("Page ").PageNumber(-42).Text(" of ").NumberOfPages()
+                            .Center().SheetName()
+                            .Right().FileName()
+                            .ToString());
 
-        var headerFooter = new XlsxHeaderFooter(
-            oddHeader: new XlsxHeaderFooterBuilder()
-                .Left().Bold().Text(nameof(HeaderFooterPageBreaks)).Bold().Text(" example")
-                .ToString(),
-            oddFooter: new XlsxHeaderFooterBuilder()
-                .Left().Text("Page ").PageNumber(-42).Text(" of ").NumberOfPages()
-                .Center().SheetName()
-                .Right().FileName()
-                .ToString());
-
-        xlsxWriter.BeginWorksheet("Sheet1")
-            .SetHeaderFooter(headerFooter)
-            .BeginRow().Write("A1").Write("B1").AddColumnPageBreak().Write("C1")
-            .BeginRow().Write("A2").Write("B2").Write("C2")
-            .BeginRow().Write("A3").AddRowPageBreak().Write("B3").Write("C3")
-            .BeginRow().Write("A4").Write("B4").Write("C4");
+                    xlsxWriter.BeginWorksheet("Sheet1")
+                        .SetHeaderFooter(headerFooter)
+                        .BeginRow().Write("A1").Write("B1").AddColumnPageBreak().Write("C1")
+                        .BeginRow().Write("A2").Write("B2").Write("C2")
+                        .BeginRow().Write("A3").AddRowPageBreak().Write("B3").Write("C3")
+                        .BeginRow().Write("A4").Write("B4").Write("C4");
+                }
+            }
+        }
     }
 }

--- a/Examples/HideGridlines.cs
+++ b/Examples/HideGridlines.cs
@@ -28,23 +28,29 @@ using System.Drawing;
 using System.IO;
 using LargeXlsx;
 
-namespace Examples;
-
-public static class HideGridlines
+namespace Examples
 {
-    public static void Run()
+    public static class HideGridlines
     {
-        var xlsxStyle = XlsxStyle.Default.With(XlsxBorder.Around(new XlsxBorder.Line(Color.Black, XlsxBorder.Style.Dotted)));
-        using var stream = new FileStream($"{nameof(HideGridlines)}.xlsx", FileMode.Create, FileAccess.Write);
-        using var xlsxWriter = new XlsxWriter(stream);
-        xlsxWriter
-            .BeginWorksheet("HiddenGridlines", showGridLines: false)
-            .BeginRow().Write("A1", xlsxStyle).Write("B1", xlsxStyle).Write("C1", xlsxStyle)
-            .BeginRow().Write("A2", xlsxStyle).Write("B2", xlsxStyle).Write("C2", xlsxStyle)
-            .BeginRow().Write("A3", xlsxStyle).Write("B3", xlsxStyle).Write("C3", xlsxStyle)
-            .BeginWorksheet("HiddenHeaders", showHeaders: false)
-            .BeginRow()
-            .BeginRow().Write("").Write("This sheet have row and columns headers hidden by default")
-            .BeginRow();
+        public static void Run()
+        {
+            var xlsxStyle =
+                XlsxStyle.Default.With(XlsxBorder.Around(new XlsxBorder.Line(Color.Black, XlsxBorder.Style.Dotted)));
+            using (var stream = new FileStream($"{nameof(HideGridlines)}.xlsx", FileMode.Create, FileAccess.Write))
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                {
+                    xlsxWriter
+                        .BeginWorksheet("HiddenGridlines", showGridLines: false)
+                        .BeginRow().Write("A1", xlsxStyle).Write("B1", xlsxStyle).Write("C1", xlsxStyle)
+                        .BeginRow().Write("A2", xlsxStyle).Write("B2", xlsxStyle).Write("C2", xlsxStyle)
+                        .BeginRow().Write("A3", xlsxStyle).Write("B3", xlsxStyle).Write("C3", xlsxStyle)
+                        .BeginWorksheet("HiddenHeaders", showHeaders: false)
+                        .BeginRow()
+                        .BeginRow().Write("").Write("This sheet have row and columns headers hidden by default")
+                        .BeginRow();
+                }
+            }
+        }
     }
 }

--- a/Examples/InlineStrings.cs
+++ b/Examples/InlineStrings.cs
@@ -3,31 +3,36 @@ using System.Diagnostics;
 using System.IO;
 using LargeXlsx;
 
-namespace Examples;
-
-public static class InlineStrings
+namespace Examples
 {
-    private const int RowCount = 1_000_000;
-
-    public static void Run()
+    public static class InlineStrings
     {
-        var stopwatch = Stopwatch.StartNew();
-        DoRun();
-        stopwatch.Stop();
-        Console.WriteLine($"{nameof(InlineStrings)} completed in {stopwatch.ElapsedMilliseconds} ms.");
-    }
+        private const int RowCount = 1_000_000;
 
-    private static void DoRun()
-    {
-        using var stream = new FileStream($"{nameof(InlineStrings)}.xlsx", FileMode.Create, FileAccess.Write);
-        using var xlsxWriter = new XlsxWriter(stream);
-        xlsxWriter.BeginWorksheet("Sheet1");
-        for (var i = 0; i < RowCount; i++)
+        public static void Run()
         {
-            xlsxWriter.BeginRow()
-                .Write("  Leading spaces")
-                .Write("Trailing spaces   ")
-                .Write("Spaces  in   between");
+            var stopwatch = Stopwatch.StartNew();
+            DoRun();
+            stopwatch.Stop();
+            Console.WriteLine($"{nameof(InlineStrings)} completed in {stopwatch.ElapsedMilliseconds} ms.");
+        }
+
+        private static void DoRun()
+        {
+            using (var stream = new FileStream($"{nameof(InlineStrings)}.xlsx", FileMode.Create, FileAccess.Write))
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                {
+                    xlsxWriter.BeginWorksheet("Sheet1");
+                    for (var i = 0; i < RowCount; i++)
+                    {
+                        xlsxWriter.BeginRow()
+                            .Write("  Leading spaces")
+                            .Write("Trailing spaces   ")
+                            .Write("Spaces  in   between");
+                    }
+                }
+            }
         }
     }
 }

--- a/Examples/InvalidXmlChars.cs
+++ b/Examples/InvalidXmlChars.cs
@@ -29,24 +29,29 @@ using System.Diagnostics;
 using System.IO;
 using LargeXlsx;
 
-namespace Examples;
-
-public static class InvalidXmlChars
+namespace Examples
 {
-    public static void Run()
+    public static class InvalidXmlChars
     {
-        var stopwatch = Stopwatch.StartNew();
-        DoRun();
-        stopwatch.Stop();
-        Console.WriteLine($"{nameof(InvalidXmlChars)} completed in {stopwatch.ElapsedMilliseconds} ms.");
-    }
+        public static void Run()
+        {
+            var stopwatch = Stopwatch.StartNew();
+            DoRun();
+            stopwatch.Stop();
+            Console.WriteLine($"{nameof(InvalidXmlChars)} completed in {stopwatch.ElapsedMilliseconds} ms.");
+        }
 
-    private static void DoRun()
-    {
-        using var stream = new FileStream($"{nameof(InvalidXmlChars)}.xlsx", FileMode.Create, FileAccess.Write);
-        using var xlsxWriter = new XlsxWriter(stream, skipInvalidCharacters: true);
-        xlsxWriter.BeginWorksheet("Sheet1")
-            .BeginRow().Write("Inline str\u0002ing")
-            .BeginRow().WriteSharedString("Shared str\u0002ing");
+        private static void DoRun()
+        {
+            using (var stream = new FileStream($"{nameof(InvalidXmlChars)}.xlsx", FileMode.Create, FileAccess.Write))
+            {
+                using (var xlsxWriter = new XlsxWriter(stream, skipInvalidCharacters: true))
+                {
+                    xlsxWriter.BeginWorksheet("Sheet1")
+                        .BeginRow().Write("Inline str\u0002ing")
+                        .BeginRow().WriteSharedString("Shared str\u0002ing");
+                }
+            }
+        }
     }
 }

--- a/Examples/Large.cs
+++ b/Examples/Large.cs
@@ -31,44 +31,54 @@ using System.IO;
 using LargeXlsx;
 using SharpCompress.Compressors.Deflate;
 
-namespace Examples;
-
-public static class Large
+namespace Examples
 {
-    private const int RowCount = 50000;
-    private const int ColumnCount = 180;
-
-    public static void Run()
+    public static class Large
     {
-        var stopwatch = Stopwatch.StartNew();
-        DoRun(requireCellReferences: true);
-        stopwatch.Stop();
-        Console.WriteLine($"{nameof(Large)} requiring references completed {RowCount} rows and {ColumnCount} columns in {stopwatch.ElapsedMilliseconds} ms.");
+        private const int RowCount = 50000;
+        private const int ColumnCount = 180;
 
-        stopwatch.Restart();
-        DoRun(requireCellReferences: false);
-        stopwatch.Stop();
-        Console.WriteLine($"{nameof(Large)} omitting references completed {RowCount} rows and {ColumnCount} columns in {stopwatch.ElapsedMilliseconds} ms.");
-    }
-
-    private static void DoRun(bool requireCellReferences)
-    {
-        using var stream = new FileStream($"{nameof(Large)}_{requireCellReferences}.xlsx", FileMode.Create, FileAccess.Write);
-        using var xlsxWriter = new XlsxWriter(stream, compressionLevel: CompressionLevel.Level3, requireCellReferences: requireCellReferences);
-        var whiteFont = new XlsxFont("Calibri", 11, Color.White, bold: true);
-        var blueFill = new XlsxFill(Color.FromArgb(0, 0x45, 0x86));
-        var headerStyle = new XlsxStyle(whiteFont, blueFill, XlsxBorder.None, XlsxNumberFormat.General, XlsxAlignment.Default);
-        var numberStyle = XlsxStyle.Default.With(XlsxNumberFormat.ThousandTwoDecimal);
-
-        xlsxWriter.BeginWorksheet("Sheet1", 1, 1);
-        xlsxWriter.BeginRow();
-        for (var j = 0; j < ColumnCount; j++)
-            xlsxWriter.Write($"Column {j}", headerStyle);
-        for (var i = 0; i < RowCount; i++)
+        public static void Run()
         {
-            xlsxWriter.BeginRow().Write($"Row {i}");
-            for (var j = 1; j < ColumnCount; j++)
-                xlsxWriter.Write(i * 1000 + j, numberStyle);
+            var stopwatch = Stopwatch.StartNew();
+            DoRun(requireCellReferences: true);
+            stopwatch.Stop();
+            Console.WriteLine(
+                $"{nameof(Large)} requiring references completed {RowCount} rows and {ColumnCount} columns in {stopwatch.ElapsedMilliseconds} ms.");
+
+            stopwatch.Restart();
+            DoRun(requireCellReferences: false);
+            stopwatch.Stop();
+            Console.WriteLine(
+                $"{nameof(Large)} omitting references completed {RowCount} rows and {ColumnCount} columns in {stopwatch.ElapsedMilliseconds} ms.");
+        }
+
+        private static void DoRun(bool requireCellReferences)
+        {
+            using (var stream = new FileStream($"{nameof(Large)}_{requireCellReferences}.xlsx", FileMode.Create,
+                       FileAccess.Write))
+            {
+                using (var xlsxWriter = new XlsxWriter(stream, compressionLevel: CompressionLevel.Level3,
+                           requireCellReferences: requireCellReferences))
+                {
+                    var whiteFont = new XlsxFont("Calibri", 11, Color.White, bold: true);
+                    var blueFill = new XlsxFill(Color.FromArgb(0, 0x45, 0x86));
+                    var headerStyle = new XlsxStyle(whiteFont, blueFill, XlsxBorder.None, XlsxNumberFormat.General,
+                        XlsxAlignment.Default);
+                    var numberStyle = XlsxStyle.Default.With(XlsxNumberFormat.ThousandTwoDecimal);
+
+                    xlsxWriter.BeginWorksheet("Sheet1", 1, 1);
+                    xlsxWriter.BeginRow();
+                    for (var j = 0; j < ColumnCount; j++)
+                        xlsxWriter.Write($"Column {j}", headerStyle);
+                    for (var i = 0; i < RowCount; i++)
+                    {
+                        xlsxWriter.BeginRow().Write($"Row {i}");
+                        for (var j = 1; j < ColumnCount; j++)
+                            xlsxWriter.Write(i * 1000 + j, numberStyle);
+                    }
+                }
+            }
         }
     }
 }

--- a/Examples/MultipleSheet.cs
+++ b/Examples/MultipleSheet.cs
@@ -29,36 +29,47 @@ using System.Drawing;
 using System.IO;
 using LargeXlsx;
 
-namespace Examples;
-
-public static class MultipleSheet
+namespace Examples
 {
-    public static void Run()
+    public static class MultipleSheet
     {
-        using var stream = new FileStream($"{nameof(MultipleSheet)}.xlsx", FileMode.Create, FileAccess.Write);
-        using var xlsxWriter = new XlsxWriter(stream);
-        var whiteFont = new XlsxFont("Segoe UI", 9, Color.White, bold: true);
-        var blueFill = new XlsxFill(Color.FromArgb(0, 0x45, 0x86));
-        var yellowFill = new XlsxFill(Color.FromArgb(0xff, 0xff, 0x88));
-        var headerStyle = new XlsxStyle(whiteFont, blueFill, XlsxBorder.None, XlsxNumberFormat.General, XlsxAlignment.Default);
-        var highlightStyle = XlsxStyle.Default.With(yellowFill);
-        var dateStyle = XlsxStyle.Default.With(XlsxNumberFormat.ShortDateTime);
+        public static void Run()
+        {
+            using (var stream = new FileStream($"{nameof(MultipleSheet)}.xlsx", FileMode.Create, FileAccess.Write))
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                {
+                    var whiteFont = new XlsxFont("Segoe UI", 9, Color.White, bold: true);
+                    var blueFill = new XlsxFill(Color.FromArgb(0, 0x45, 0x86));
+                    var yellowFill = new XlsxFill(Color.FromArgb(0xff, 0xff, 0x88));
+                    var headerStyle = new XlsxStyle(whiteFont, blueFill, XlsxBorder.None, XlsxNumberFormat.General,
+                        XlsxAlignment.Default);
+                    var highlightStyle = XlsxStyle.Default.With(yellowFill);
+                    var dateStyle = XlsxStyle.Default.With(XlsxNumberFormat.ShortDateTime);
 
-        xlsxWriter
-            .BeginWorksheet("Sheet&'<1>\"", splitColumn: 1, splitRow: 2, columns: new[] { XlsxColumn.Unformatted(count: 2), XlsxColumn.Formatted(width: 20) })
-            .SetDefaultStyle(headerStyle)
-            .BeginRow().Write("Col<1>").Write("Col2").Write("Col&3")
-            .BeginRow().Write().Write("Sub2").Write("Sub3")
-            .SetDefaultStyle(XlsxStyle.Default)
-            .BeginRow().Write("Row3").Write(42).WriteFormula("B3*10", highlightStyle)
-            .BeginRow().Write("Row4").SkipColumns(1).Write(new DateTime(2020, 5, 6, 18, 27, 0), dateStyle)
-            .SkipRows(2)
-            .BeginRow().Write("Row7", XlsxStyle.Default.With(XlsxBorder.Around(new XlsxBorder.Line(Color.DeepPink, XlsxBorder.Style.Dashed))), columnSpan: 2).Write(3.14159265359)
-            .SetAutoFilter(1, 1, xlsxWriter.CurrentRowNumber, 3)
-            .BeginWorksheet("Sheet2", splitColumn: 1, splitRow: 1)
-            .BeginRow().Write("Lorem ipsum dolor sit amet,")
-            .BeginRow().Write("consectetur adipiscing elit,")
-            .BeginRow().Write("sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.")
-            .SetAutoFilter(1, 1, xlsxWriter.CurrentRowNumber, 1);
+                    xlsxWriter
+                        .BeginWorksheet("Sheet&'<1>\"", splitColumn: 1, splitRow: 2,
+                            columns: new[] {XlsxColumn.Unformatted(count: 2), XlsxColumn.Formatted(width: 20)})
+                        .SetDefaultStyle(headerStyle)
+                        .BeginRow().Write("Col<1>").Write("Col2").Write("Col&3")
+                        .BeginRow().Write().Write("Sub2").Write("Sub3")
+                        .SetDefaultStyle(XlsxStyle.Default)
+                        .BeginRow().Write("Row3").Write(42).WriteFormula("B3*10", highlightStyle)
+                        .BeginRow().Write("Row4").SkipColumns(1).Write(new DateTime(2020, 5, 6, 18, 27, 0), dateStyle)
+                        .SkipRows(2)
+                        .BeginRow().Write("Row7",
+                            XlsxStyle.Default.With(
+                                XlsxBorder.Around(new XlsxBorder.Line(Color.DeepPink, XlsxBorder.Style.Dashed))),
+                            columnSpan: 2)
+                        .Write(3.14159265359)
+                        .SetAutoFilter(1, 1, xlsxWriter.CurrentRowNumber, 3)
+                        .BeginWorksheet("Sheet2", splitColumn: 1, splitRow: 1)
+                        .BeginRow().Write("Lorem ipsum dolor sit amet,")
+                        .BeginRow().Write("consectetur adipiscing elit,")
+                        .BeginRow().Write("sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.")
+                        .SetAutoFilter(1, 1, xlsxWriter.CurrentRowNumber, 1);
+                }
+            }
+        }
     }
 }

--- a/Examples/NumberFormats.cs
+++ b/Examples/NumberFormats.cs
@@ -27,45 +27,66 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 using System.IO;
 using LargeXlsx;
 
-namespace Examples;
-
-public static class NumberFormats
+namespace Examples
 {
-    public static void Run()
+    public static class NumberFormats
     {
-        using var stream = new FileStream($"{nameof(NumberFormats)}.xlsx", FileMode.Create, FileAccess.Write);
-        using var xlsxWriter = new XlsxWriter(stream);
-        var customNumberFormat1 = new XlsxNumberFormat("0.0%");
-        var customNumberFormat2 = new XlsxNumberFormat("#,##0.00####");
+        public static void Run()
+        {
+            using (var stream = new FileStream($"{nameof(NumberFormats)}.xlsx", FileMode.Create, FileAccess.Write))
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                {
+                    var customNumberFormat1 = new XlsxNumberFormat("0.0%");
+                    var customNumberFormat2 = new XlsxNumberFormat("#,##0.00####");
 
-        var generalStyle = XlsxStyle.Default.With(XlsxNumberFormat.General);
-        var integerStyle = XlsxStyle.Default.With(XlsxNumberFormat.Integer);
-        var twoDecimalStyle = XlsxStyle.Default.With(XlsxNumberFormat.TwoDecimal);
-        var thousandIntegerStyle = XlsxStyle.Default.With(XlsxNumberFormat.ThousandInteger);
-        var thousandTwoDecimalStyle = XlsxStyle.Default.With(XlsxNumberFormat.ThousandTwoDecimal);
-        var integerPercentageStyle = XlsxStyle.Default.With(XlsxNumberFormat.IntegerPercentage);
-        var twoDecimalPercentageStyle = XlsxStyle.Default.With(XlsxNumberFormat.TwoDecimalPercentage);
-        var scientificStyle = XlsxStyle.Default.With(XlsxNumberFormat.Scientific);
-        var shortDateStyle = XlsxStyle.Default.With(XlsxNumberFormat.ShortDate);
-        var shortDateTimeStyle = XlsxStyle.Default.With(XlsxNumberFormat.ShortDateTime);
-        var textStyle = XlsxStyle.Default.With(XlsxNumberFormat.Text);
-        var customStyle1 = XlsxStyle.Default.With(customNumberFormat1);
-        var customStyle2 = XlsxStyle.Default.With(customNumberFormat2);
+                    var generalStyle = XlsxStyle.Default.With(XlsxNumberFormat.General);
+                    var integerStyle = XlsxStyle.Default.With(XlsxNumberFormat.Integer);
+                    var twoDecimalStyle = XlsxStyle.Default.With(XlsxNumberFormat.TwoDecimal);
+                    var thousandIntegerStyle = XlsxStyle.Default.With(XlsxNumberFormat.ThousandInteger);
+                    var thousandTwoDecimalStyle = XlsxStyle.Default.With(XlsxNumberFormat.ThousandTwoDecimal);
+                    var integerPercentageStyle = XlsxStyle.Default.With(XlsxNumberFormat.IntegerPercentage);
+                    var twoDecimalPercentageStyle = XlsxStyle.Default.With(XlsxNumberFormat.TwoDecimalPercentage);
+                    var scientificStyle = XlsxStyle.Default.With(XlsxNumberFormat.Scientific);
+                    var shortDateStyle = XlsxStyle.Default.With(XlsxNumberFormat.ShortDate);
+                    var shortDateTimeStyle = XlsxStyle.Default.With(XlsxNumberFormat.ShortDateTime);
+                    var textStyle = XlsxStyle.Default.With(XlsxNumberFormat.Text);
+                    var customStyle1 = XlsxStyle.Default.With(customNumberFormat1);
+                    var customStyle2 = XlsxStyle.Default.With(customNumberFormat2);
 
-        xlsxWriter
-            .BeginWorksheet("Sheet1")
-            .BeginRow().Write(nameof(XlsxNumberFormat.General)).Write(1234.5678, generalStyle).Write(1.2, generalStyle)
-            .BeginRow().Write(nameof(XlsxNumberFormat.Integer)).Write(1234.5678, integerStyle).Write(1.2, integerStyle)
-            .BeginRow().Write(nameof(XlsxNumberFormat.TwoDecimal)).Write(1234.5678, twoDecimalStyle).Write(1.2, twoDecimalStyle)
-            .BeginRow().Write(nameof(XlsxNumberFormat.ThousandInteger)).Write(1234.5678, thousandIntegerStyle).Write(1.2, thousandIntegerStyle)
-            .BeginRow().Write(nameof(XlsxNumberFormat.ThousandTwoDecimal)).Write(1234.5678, thousandTwoDecimalStyle).Write(1.2, thousandTwoDecimalStyle)
-            .BeginRow().Write(nameof(XlsxNumberFormat.IntegerPercentage)).Write(1234.5678, integerPercentageStyle).Write(1.2, integerPercentageStyle)
-            .BeginRow().Write(nameof(XlsxNumberFormat.TwoDecimalPercentage)).Write(1234.5678, twoDecimalPercentageStyle).Write(1.2, twoDecimalPercentageStyle)
-            .BeginRow().Write(nameof(XlsxNumberFormat.Scientific)).Write(1234.5678, scientificStyle).Write(1.2, scientificStyle)
-            .BeginRow().Write(nameof(XlsxNumberFormat.ShortDate)).Write(1234.5678, shortDateStyle).Write(1.2, shortDateStyle)
-            .BeginRow().Write(nameof(XlsxNumberFormat.ShortDateTime)).Write(1234.5678, shortDateTimeStyle).Write(1.2, shortDateTimeStyle)
-            .BeginRow().Write(nameof(XlsxNumberFormat.Text)).Write(1234.5678, textStyle).Write(1.2, textStyle)
-            .BeginRow().Write(customNumberFormat1.FormatCode).Write(1234.5678, customStyle1).Write(1.2, customStyle1)
-            .BeginRow().Write(customNumberFormat2.FormatCode).Write(1234.5678, customStyle2).Write(1.2, customStyle2);
+                    xlsxWriter
+                        .BeginWorksheet("Sheet1")
+                        .BeginRow().Write(nameof(XlsxNumberFormat.General)).Write(1234.5678, generalStyle)
+                        .Write(1.2, generalStyle)
+                        .BeginRow().Write(nameof(XlsxNumberFormat.Integer)).Write(1234.5678, integerStyle)
+                        .Write(1.2, integerStyle)
+                        .BeginRow().Write(nameof(XlsxNumberFormat.TwoDecimal)).Write(1234.5678, twoDecimalStyle)
+                        .Write(1.2, twoDecimalStyle)
+                        .BeginRow().Write(nameof(XlsxNumberFormat.ThousandInteger))
+                        .Write(1234.5678, thousandIntegerStyle)
+                        .Write(1.2, thousandIntegerStyle)
+                        .BeginRow().Write(nameof(XlsxNumberFormat.ThousandTwoDecimal))
+                        .Write(1234.5678, thousandTwoDecimalStyle)
+                        .Write(1.2, thousandTwoDecimalStyle)
+                        .BeginRow().Write(nameof(XlsxNumberFormat.IntegerPercentage))
+                        .Write(1234.5678, integerPercentageStyle)
+                        .Write(1.2, integerPercentageStyle)
+                        .BeginRow().Write(nameof(XlsxNumberFormat.TwoDecimalPercentage))
+                        .Write(1234.5678, twoDecimalPercentageStyle).Write(1.2, twoDecimalPercentageStyle)
+                        .BeginRow().Write(nameof(XlsxNumberFormat.Scientific)).Write(1234.5678, scientificStyle)
+                        .Write(1.2, scientificStyle)
+                        .BeginRow().Write(nameof(XlsxNumberFormat.ShortDate)).Write(1234.5678, shortDateStyle)
+                        .Write(1.2, shortDateStyle)
+                        .BeginRow().Write(nameof(XlsxNumberFormat.ShortDateTime)).Write(1234.5678, shortDateTimeStyle)
+                        .Write(1.2, shortDateTimeStyle)
+                        .BeginRow().Write(nameof(XlsxNumberFormat.Text)).Write(1234.5678, textStyle)
+                        .Write(1.2, textStyle)
+                        .BeginRow().Write(customNumberFormat1.FormatCode).Write(1234.5678, customStyle1)
+                        .Write(1.2, customStyle1)
+                        .BeginRow().Write(customNumberFormat2.FormatCode).Write(1234.5678, customStyle2)
+                        .Write(1.2, customStyle2);
+                }
+            }
+        }
     }
 }

--- a/Examples/Program.cs
+++ b/Examples/Program.cs
@@ -26,34 +26,43 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 using System;
 
-namespace Examples;
-
-public static class Program
+namespace Examples
 {
-    public static void Main(string[] _)
+    public static class Program
     {
-        Simple.Run();
-        MultipleSheet.Run();
-        FrozenPanes.Run();
-        HideGridlines.Run();
-        WorksheetVisibility.Run();
-        NumberFormats.Run();
-        ColumnFormatting.Run();
-        RowFormatting.Run();
-        Alignment.Run();
-        Border.Run();
-        DataValidation.Run();
-        RightToLeft.Run();
-        Zip64Small.Run();
-        SheetProtection.Run();
-        HeaderFooterPageBreaks.Run();
-        InvalidXmlChars.Run();
-        InlineStrings.Run();
-        SharedStrings.Run();
-        Large.Run();
-        StyledLarge.Run();
-        StyledLargeCreateStyles.Run();
-        Zip64Huge.Run();
-        Console.WriteLine($"Gen0: {GC.CollectionCount(0)} Gen1: {GC.CollectionCount(1)} Gen2: {GC.CollectionCount(2)} TotalAllocatedBytes: {GC.GetTotalAllocatedBytes()}");
+        public static void Main(string[] _)
+        {
+            Simple.Run();
+            MultipleSheet.Run();
+            FrozenPanes.Run();
+            HideGridlines.Run();
+            WorksheetVisibility.Run();
+            NumberFormats.Run();
+            ColumnFormatting.Run();
+            RowFormatting.Run();
+            Alignment.Run();
+            Border.Run();
+            DataValidation.Run();
+            RightToLeft.Run();
+            Zip64Small.Run();
+            SheetProtection.Run();
+            HeaderFooterPageBreaks.Run();
+            InvalidXmlChars.Run();
+            InlineStrings.Run();
+            SharedStrings.Run();
+            Large.Run();
+            StyledLarge.Run();
+            StyledLargeCreateStyles.Run();
+            Zip64Huge.Run();
+
+            // ... existing code ...
+
+#if NET6_0_OR_GREATER
+    Console.WriteLine($"Gen0: {GC.CollectionCount(0)} Gen1: {GC.CollectionCount(1)} Gen2: {GC.CollectionCount(2)} TotalAllocatedBytes: {GC.GetTotalAllocatedBytes()}");
+#else
+            Console.WriteLine(
+                $"Gen0: {GC.CollectionCount(0)} Gen1: {GC.CollectionCount(1)} Gen2: {GC.CollectionCount(2)}");
+#endif
+        }
     }
 }

--- a/Examples/RightToLeft.cs
+++ b/Examples/RightToLeft.cs
@@ -27,17 +27,21 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 using System.IO;
 using LargeXlsx;
 
-namespace Examples;
-
-public static class RightToLeft
+namespace Examples
 {
-    public static void Run()
+    public static class RightToLeft
     {
-        using var stream = new FileStream($"{nameof(RightToLeft)}.xlsx", FileMode.Create, FileAccess.Write);
-        using var xlsxWriter = new XlsxWriter(stream);
-        xlsxWriter
-            .BeginWorksheet("Sheet 1", rightToLeft: true)
-            .BeginRow().Write(@"ما هو ""لوريم إيبسوم"" ؟")
-            .BeginRow().Write(@"لوريم إيبسوم(Lorem Ipsum) هو ببساطة نص شكلي (بمعنى أن الغاية هي الشكل وليس المحتوى) ويُستخدم في صناعات المطابع ودور النشر.");
+        public static void Run()
+        {
+            using (var stream = new FileStream($"{nameof(RightToLeft)}.xlsx", FileMode.Create, FileAccess.Write))
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                    xlsxWriter
+                        .BeginWorksheet("Sheet 1", rightToLeft: true)
+                        .BeginRow().Write(@"ما هو ""لوريم إيبسوم"" ؟")
+                        .BeginRow().Write(
+                            @"لوريم إيبسوم(Lorem Ipsum) هو ببساطة نص شكلي (بمعنى أن الغاية هي الشكل وليس المحتوى) ويُستخدم في صناعات المطابع ودور النشر.");
+            }
+        }
     }
 }

--- a/Examples/RowFormatting.cs
+++ b/Examples/RowFormatting.cs
@@ -28,21 +28,28 @@ using System.Drawing;
 using System.IO;
 using LargeXlsx;
 
-namespace Examples;
-
-public static class RowFormatting
+namespace Examples
 {
-    public static void Run()
+    public static class RowFormatting
     {
-        using var stream = new FileStream($"{nameof(RowFormatting)}.xlsx", FileMode.Create, FileAccess.Write);
-        using var xlsxWriter = new XlsxWriter(stream);
-        var blueStyle = new XlsxStyle(XlsxFont.Default.With(Color.White), new XlsxFill(Color.FromArgb(0, 0x45, 0x86)), XlsxBorder.None, XlsxNumberFormat.General, XlsxAlignment.Default);
-        xlsxWriter
-            .BeginWorksheet("Sheet 1")
-            .BeginRow().Write("A1").Write("B1").Write("C1")
-            .BeginRow(hidden: true).Write("A2").Write("B2").Write("C2")
-            .BeginRow().Write("A3").Write("B3").Write("C3")
-            .BeginRow(height: 36.5).Write("A4").Write("B4").Write("C4")
-            .BeginRow(style: blueStyle).Write("A5").SkipColumns(1).Write("C5");
+        public static void Run()
+        {
+            using (var stream = new FileStream($"{nameof(RowFormatting)}.xlsx", FileMode.Create, FileAccess.Write))
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                {
+                    var blueStyle = new XlsxStyle(XlsxFont.Default.With(Color.White),
+                        new XlsxFill(Color.FromArgb(0, 0x45, 0x86)), XlsxBorder.None, XlsxNumberFormat.General,
+                        XlsxAlignment.Default);
+                    xlsxWriter
+                        .BeginWorksheet("Sheet 1")
+                        .BeginRow().Write("A1").Write("B1").Write("C1")
+                        .BeginRow(hidden: true).Write("A2").Write("B2").Write("C2")
+                        .BeginRow().Write("A3").Write("B3").Write("C3")
+                        .BeginRow(height: 36.5).Write("A4").Write("B4").Write("C4")
+                        .BeginRow(style: blueStyle).Write("A5").SkipColumns(1).Write("C5");
+                }
+            }
+        }
     }
 }

--- a/Examples/SharedStrings.cs
+++ b/Examples/SharedStrings.cs
@@ -29,39 +29,45 @@ using System.Diagnostics;
 using System.IO;
 using LargeXlsx;
 
-namespace Examples;
-
-public static class SharedStrings
+namespace Examples
 {
-    private const int RowCount = 1_000_000;
-
-    public static void Run()
+    public static class SharedStrings
     {
-        var stopwatch = Stopwatch.StartNew();
-        DoRun();
-        stopwatch.Stop();
-        Console.WriteLine($"{nameof(SharedStrings)} completed in {stopwatch.ElapsedMilliseconds} ms.");
-    }
+        private const int RowCount = 1_000_000;
 
-    private static void DoRun()
-    {
-        using var stream = new FileStream($"{nameof(SharedStrings)}.xlsx", FileMode.Create, FileAccess.Write);
-        using var xlsxWriter = new XlsxWriter(stream);
-        xlsxWriter.BeginWorksheet("Sheet1").BeginRow().Write("This string is not shared");
-        for (var i = 0; i < RowCount; i++)
+        public static void Run()
         {
-            xlsxWriter.BeginRow()
-                .WriteSharedString("Lorem ipsum dolor sit amet")
-                .WriteSharedString("consectetur adipiscing elit")
-                .WriteSharedString("sed do eiusmod tempor incididunt ut labore et dolore magna aliqua");
+            var stopwatch = Stopwatch.StartNew();
+            DoRun();
+            stopwatch.Stop();
+            Console.WriteLine($"{nameof(SharedStrings)} completed in {stopwatch.ElapsedMilliseconds} ms.");
         }
-        xlsxWriter.BeginWorksheet("Sheet2").BeginRow().Write("This string is not shared either");
-        for (var i = 0; i < RowCount; i++)
+
+        private static void DoRun()
         {
-            xlsxWriter.BeginRow()
-                .WriteSharedString("  Leading spaces")
-                .WriteSharedString("Trailing spaces   ")
-                .WriteSharedString("Spaces  in   between");
+            using (var stream = new FileStream($"{nameof(SharedStrings)}.xlsx", FileMode.Create, FileAccess.Write))
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                {
+                    xlsxWriter.BeginWorksheet("Sheet1").BeginRow().Write("This string is not shared");
+                    for (var i = 0; i < RowCount; i++)
+                    {
+                        xlsxWriter.BeginRow()
+                            .WriteSharedString("Lorem ipsum dolor sit amet")
+                            .WriteSharedString("consectetur adipiscing elit")
+                            .WriteSharedString("sed do eiusmod tempor incididunt ut labore et dolore magna aliqua");
+                    }
+
+                    xlsxWriter.BeginWorksheet("Sheet2").BeginRow().Write("This string is not shared either");
+                    for (var i = 0; i < RowCount; i++)
+                    {
+                        xlsxWriter.BeginRow()
+                            .WriteSharedString("  Leading spaces")
+                            .WriteSharedString("Trailing spaces   ")
+                            .WriteSharedString("Spaces  in   between");
+                    }
+                }
+            }
         }
     }
 }

--- a/Examples/SheetProtection.cs
+++ b/Examples/SheetProtection.cs
@@ -28,20 +28,25 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 using System.IO;
 using LargeXlsx;
 
-namespace Examples;
-
-public static class SheetProtection
+namespace Examples
 {
-    public static void Run()
+    public static class SheetProtection
     {
-        using var stream = new FileStream($"{nameof(SheetProtection)}.xlsx", FileMode.Create, FileAccess.Write);
-        using var xlsxWriter = new XlsxWriter(stream);
-        xlsxWriter
-            .BeginWorksheet("Sheet 1")
-            .SetSheetProtection(new XlsxSheetProtection("Lorem ipsum", autoFilter: false))
-            .BeginRow().Write("A1").Write("B1")
-            .BeginRow().Write("A2").Write("B2")
-            .BeginRow().Write("A3").Write("B3")
-            .SetAutoFilter(1, 1, xlsxWriter.CurrentRowNumber - 1, 2);
+        public static void Run()
+        {
+            using (var stream = new FileStream($"{nameof(SheetProtection)}.xlsx", FileMode.Create, FileAccess.Write))
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                {
+                    xlsxWriter
+                        .BeginWorksheet("Sheet 1")
+                        .SetSheetProtection(new XlsxSheetProtection("Lorem ipsum", autoFilter: false))
+                        .BeginRow().Write("A1").Write("B1")
+                        .BeginRow().Write("A2").Write("B2")
+                        .BeginRow().Write("A3").Write("B3")
+                        .SetAutoFilter(1, 1, xlsxWriter.CurrentRowNumber - 1, 2);
+                }
+            }
+        }
     }
 }

--- a/Examples/Simple.cs
+++ b/Examples/Simple.cs
@@ -29,46 +29,64 @@ using System.Drawing;
 using System.IO;
 using LargeXlsx;
 
-namespace Examples;
-
-public static class Simple
+namespace Examples
 {
-    public static void Run()
+    public static class Simple
     {
-        using var stream = new FileStream($"{nameof(Simple)}.xlsx", FileMode.Create, FileAccess.Write);
-        using var xlsxWriter = new XlsxWriter(stream);
-        var headerStyle = new XlsxStyle(
-            new XlsxFont("Segoe UI", 9, Color.White, bold: true),
-            new XlsxFill(Color.FromArgb(0, 0x45, 0x86)),
-            XlsxStyle.Default.Border,
-            XlsxStyle.Default.NumberFormat,
-            XlsxAlignment.Default);
-        var highlightStyle = XlsxStyle.Default.With(new XlsxFill(Color.FromArgb(0xff, 0xff, 0x88)));
-        var dateStyle = XlsxStyle.Default.With(XlsxNumberFormat.ShortDateTime);
-        var borderedStyle = highlightStyle.With(XlsxBorder.Around(new XlsxBorder.Line(Color.DeepPink, XlsxBorder.Style.Dashed)));
-        var hyperlinkStyle = XlsxStyle.Default.With(XlsxFont.Default.WithUnderline().With(Color.Blue));
+        public static void Run()
+        {
+            using (var stream = new FileStream($"{nameof(Simple)}.xlsx", FileMode.Create, FileAccess.Write))
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                {
+                    var headerStyle = new XlsxStyle(
+                        new XlsxFont("Segoe UI", 9, Color.White, bold: true),
+                        new XlsxFill(Color.FromArgb(0, 0x45, 0x86)),
+                        XlsxStyle.Default.Border,
+                        XlsxStyle.Default.NumberFormat,
+                        XlsxAlignment.Default);
+                    var highlightStyle = XlsxStyle.Default.With(new XlsxFill(Color.FromArgb(0xff, 0xff, 0x88)));
+                    var dateStyle = XlsxStyle.Default.With(XlsxNumberFormat.ShortDateTime);
+                    var borderedStyle =
+                        highlightStyle.With(
+                            XlsxBorder.Around(new XlsxBorder.Line(Color.DeepPink, XlsxBorder.Style.Dashed)));
+                    var hyperlinkStyle = XlsxStyle.Default.With(XlsxFont.Default.WithUnderline().With(Color.Blue));
 
-        xlsxWriter
-            .BeginWorksheet("Sheet 1", columns: new[] { XlsxColumn.Unformatted(count: 2), XlsxColumn.Formatted(width: 20) })
-            .SetDefaultStyle(headerStyle)
-            .BeginRow().AddMergedCell(2, 1).Write("Col1").Write("Top2").Write("Top3")
-            .BeginRow().Write().Write("Col2").Write("Col3")
-            .SetDefaultStyle(XlsxStyle.Default)
-            .BeginRow().Write("Row3").Write(42).WriteFormula(
-                $"{xlsxWriter.GetRelativeColumnName(-1)}{xlsxWriter.CurrentRowNumber}*10", highlightStyle)
-            .BeginRow().Write("Row4").SkipColumns(1).Write(new DateTime(2020, 5, 6, 18, 27, 0), dateStyle)
-            .SkipRows(2)
-            .BeginRow().Write("Row7", borderedStyle, columnSpan: 2).Write(3.14159265359)
-            .BeginRow().Write("Bold").Write().Write("Be bold", XlsxStyle.Default.With(XlsxFont.Default.WithBold()))
-            .BeginRow().Write("Italic").Write().Write("Be italic", XlsxStyle.Default.With(XlsxFont.Default.WithItalic()))
-            .BeginRow().Write("Strike").Write().Write("Be struck", XlsxStyle.Default.With(XlsxFont.Default.WithStrike()))
-            .BeginRow().Write("Underline").Write().Write("Single", XlsxStyle.Default.With(XlsxFont.Default.WithUnderline()))
-            .BeginRow().Write("Underline").Write().Write("Double", XlsxStyle.Default.With(XlsxFont.Default.WithUnderline(XlsxFont.Underline.Double)))
-            .BeginRow().Write("Underline").Write().Write("SingleAccounting", XlsxStyle.Default.With(XlsxFont.Default.WithUnderline(XlsxFont.Underline.SingleAccounting)))
-            .BeginRow().Write("Underline").Write().Write("DoubleAccounting", XlsxStyle.Default.With(XlsxFont.Default.WithUnderline(XlsxFont.Underline.DoubleAccounting)))
-            .BeginRow().Write("Hyperlink").Write().WriteFormula("HYPERLINK(\"https://github.com/salvois/LargeXlsx\")", hyperlinkStyle)
-            .BeginRow().Write("Hyperlink w/alias").Write().WriteFormula("HYPERLINK(\"https://github.com/salvois/LargeXlsx\", \"LargeXlsx on GitHub\")", hyperlinkStyle)
-            .BeginRow().Write("Boolean").Write(false).Write(true)
-            .SetAutoFilter(2, 1, xlsxWriter.CurrentRowNumber - 1, 3);
+                    xlsxWriter
+                        .BeginWorksheet("Sheet 1",
+                            columns: new[] {XlsxColumn.Unformatted(count: 2), XlsxColumn.Formatted(width: 20)})
+                        .SetDefaultStyle(headerStyle)
+                        .BeginRow().AddMergedCell(2, 1).Write("Col1").Write("Top2").Write("Top3")
+                        .BeginRow().Write().Write("Col2").Write("Col3")
+                        .SetDefaultStyle(XlsxStyle.Default)
+                        .BeginRow().Write("Row3").Write(42).WriteFormula(
+                            $"{xlsxWriter.GetRelativeColumnName(-1)}{xlsxWriter.CurrentRowNumber}*10", highlightStyle)
+                        .BeginRow().Write("Row4").SkipColumns(1).Write(new DateTime(2020, 5, 6, 18, 27, 0), dateStyle)
+                        .SkipRows(2)
+                        .BeginRow().Write("Row7", borderedStyle, columnSpan: 2).Write(3.14159265359)
+                        .BeginRow().Write("Bold").Write()
+                        .Write("Be bold", XlsxStyle.Default.With(XlsxFont.Default.WithBold()))
+                        .BeginRow().Write("Italic").Write()
+                        .Write("Be italic", XlsxStyle.Default.With(XlsxFont.Default.WithItalic()))
+                        .BeginRow().Write("Strike").Write()
+                        .Write("Be struck", XlsxStyle.Default.With(XlsxFont.Default.WithStrike()))
+                        .BeginRow().Write("Underline").Write()
+                        .Write("Single", XlsxStyle.Default.With(XlsxFont.Default.WithUnderline()))
+                        .BeginRow().Write("Underline").Write().Write("Double",
+                            XlsxStyle.Default.With(XlsxFont.Default.WithUnderline(XlsxFont.Underline.Double)))
+                        .BeginRow().Write("Underline").Write().Write("SingleAccounting",
+                            XlsxStyle.Default.With(XlsxFont.Default.WithUnderline(XlsxFont.Underline.SingleAccounting)))
+                        .BeginRow().Write("Underline").Write().Write("DoubleAccounting",
+                            XlsxStyle.Default.With(XlsxFont.Default.WithUnderline(XlsxFont.Underline.DoubleAccounting)))
+                        .BeginRow().Write("Hyperlink").Write()
+                        .WriteFormula("HYPERLINK(\"https://github.com/salvois/LargeXlsx\")", hyperlinkStyle)
+                        .BeginRow().Write("Hyperlink w/alias").Write().WriteFormula(
+                            "HYPERLINK(\"https://github.com/salvois/LargeXlsx\", \"LargeXlsx on GitHub\")",
+                            hyperlinkStyle)
+                        .BeginRow().Write("Boolean").Write(false).Write(true)
+                        .SetAutoFilter(2, 1, xlsxWriter.CurrentRowNumber - 1, 3);
+                }
+            }
+        }
     }
 }

--- a/Examples/StyledLarge.cs
+++ b/Examples/StyledLarge.cs
@@ -32,54 +32,65 @@ using System.Linq;
 using LargeXlsx;
 using SharpCompress.Compressors.Deflate;
 
-namespace Examples;
-
-public static class StyledLarge
+namespace Examples
 {
-    private const int RowCount = 50000;
-    private const int ColumnCount = 180;
-    private const int ColorCount = 100;
-
-    public static void Run()
+    public static class StyledLarge
     {
-        var stopwatch = Stopwatch.StartNew();
-        DoRun(requireCellReferences: true);
-        stopwatch.Stop();
-        Console.WriteLine($"{nameof(StyledLarge)} requiring references completed {RowCount} rows, {ColumnCount} columns and {ColorCount} colors in {stopwatch.ElapsedMilliseconds} ms.");
+        private const int RowCount = 50000;
+        private const int ColumnCount = 180;
+        private const int ColorCount = 100;
 
-        stopwatch.Restart();
-        DoRun(requireCellReferences: false);
-        stopwatch.Stop();
-        Console.WriteLine($"{nameof(StyledLarge)} omitting references completed {RowCount} rows, {ColumnCount} columns and {ColorCount} colors in {stopwatch.ElapsedMilliseconds} ms.");
-    }
-
-    private static void DoRun(bool requireCellReferences)
-    {
-        var rnd = new Random();
-        using var stream = new FileStream($"{nameof(StyledLarge)}_{requireCellReferences}.xlsx", FileMode.Create, FileAccess.Write);
-        using var xlsxWriter = new XlsxWriter(stream, compressionLevel: CompressionLevel.Level3, requireCellReferences: requireCellReferences);
-        var headerStyle = new XlsxStyle(
-            new XlsxFont("Calibri", 11, Color.White, bold: true),
-            new XlsxFill(Color.FromArgb(0, 0x45, 0x86)),
-            XlsxBorder.None,
-            XlsxNumberFormat.General,
-            XlsxAlignment.Default);
-        var cellStyles = Enumerable.Repeat(0, 100)
-            .Select(_ => XlsxStyle.Default.With(new XlsxFill(Color.FromArgb(rnd.Next(256), rnd.Next(256), rnd.Next(256)))))
-            .ToList();
-
-        xlsxWriter.BeginWorksheet("Sheet1", 1, 1);
-        xlsxWriter.BeginRow();
-        for (var j = 0; j < ColumnCount; j++)
-            xlsxWriter.Write($"Column {j}", headerStyle);
-        var cellStyleIndex = 0;
-        for (var i = 0; i < RowCount; i++)
+        public static void Run()
         {
-            xlsxWriter.BeginRow().Write($"Row {i}");
-            for (var j = 1; j < 180; j++)
+            var stopwatch = Stopwatch.StartNew();
+            DoRun(requireCellReferences: true);
+            stopwatch.Stop();
+            Console.WriteLine(
+                $"{nameof(StyledLarge)} requiring references completed {RowCount} rows, {ColumnCount} columns and {ColorCount} colors in {stopwatch.ElapsedMilliseconds} ms.");
+
+            stopwatch.Restart();
+            DoRun(requireCellReferences: false);
+            stopwatch.Stop();
+            Console.WriteLine(
+                $"{nameof(StyledLarge)} omitting references completed {RowCount} rows, {ColumnCount} columns and {ColorCount} colors in {stopwatch.ElapsedMilliseconds} ms.");
+        }
+
+        private static void DoRun(bool requireCellReferences)
+        {
+            var rnd = new Random();
+            using (var stream = new FileStream($"{nameof(StyledLarge)}_{requireCellReferences}.xlsx", FileMode.Create,
+                       FileAccess.Write))
             {
-                xlsxWriter.Write(i * ColumnCount + j, cellStyles[cellStyleIndex]);
-                cellStyleIndex = (cellStyleIndex + 1) % cellStyles.Count;
+                using (var xlsxWriter = new XlsxWriter(stream, compressionLevel: CompressionLevel.Level3,
+                           requireCellReferences: requireCellReferences))
+                {
+                    var headerStyle = new XlsxStyle(
+                        new XlsxFont("Calibri", 11, Color.White, bold: true),
+                        new XlsxFill(Color.FromArgb(0, 0x45, 0x86)),
+                        XlsxBorder.None,
+                        XlsxNumberFormat.General,
+                        XlsxAlignment.Default);
+                    var cellStyles = Enumerable.Repeat(0, 100)
+                        .Select(_ =>
+                            XlsxStyle.Default.With(
+                                new XlsxFill(Color.FromArgb(rnd.Next(256), rnd.Next(256), rnd.Next(256)))))
+                        .ToList();
+
+                    xlsxWriter.BeginWorksheet("Sheet1", 1, 1);
+                    xlsxWriter.BeginRow();
+                    for (var j = 0; j < ColumnCount; j++)
+                        xlsxWriter.Write($"Column {j}", headerStyle);
+                    var cellStyleIndex = 0;
+                    for (var i = 0; i < RowCount; i++)
+                    {
+                        xlsxWriter.BeginRow().Write($"Row {i}");
+                        for (var j = 1; j < 180; j++)
+                        {
+                            xlsxWriter.Write(i * ColumnCount + j, cellStyles[cellStyleIndex]);
+                            cellStyleIndex = (cellStyleIndex + 1) % cellStyles.Count;
+                        }
+                    }
+                }
             }
         }
     }

--- a/Examples/StyledLargeCreateStyles.cs
+++ b/Examples/StyledLargeCreateStyles.cs
@@ -31,52 +31,62 @@ using System.IO;
 using System.Linq;
 using LargeXlsx;
 
-namespace Examples;
-
-public static class StyledLargeCreateStyles
+namespace Examples
 {
-    private const int RowCount = 50000;
-    private const int ColumnCount = 180;
-    private const int ColorCount = 100;
-
-    public static void Run()
+    public static class StyledLargeCreateStyles
     {
-        var stopwatch = Stopwatch.StartNew();
-        DoRun(requireCellReferences: true);
-        stopwatch.Stop();
-        Console.WriteLine($"{nameof(StyledLargeCreateStyles)} requiring references completed {RowCount} rows, {ColumnCount} columns and {ColorCount} colors in {stopwatch.ElapsedMilliseconds} ms.");
+        private const int RowCount = 50000;
+        private const int ColumnCount = 180;
+        private const int ColorCount = 100;
 
-        stopwatch.Restart();
-        DoRun(requireCellReferences: false);
-        stopwatch.Stop();
-        Console.WriteLine($"{nameof(StyledLargeCreateStyles)} omitting references completed {RowCount} rows, {ColumnCount} columns and {ColorCount} colors in {stopwatch.ElapsedMilliseconds} ms.");
-    }
-
-    private static void DoRun(bool requireCellReferences)
-    {
-        var rnd = new Random();
-        using var stream = new FileStream($"{nameof(StyledLargeCreateStyles)}_{requireCellReferences}.xlsx", FileMode.Create, FileAccess.Write);
-        using var xlsxWriter = new XlsxWriter(stream, requireCellReferences: requireCellReferences);
-        var colors = Enumerable.Repeat(0, 100).Select(_ => Color.FromArgb(rnd.Next(256), rnd.Next(256), rnd.Next(256))).ToList();
-        var headerStyle = new XlsxStyle(
-            new XlsxFont("Calibri", 10.5, Color.White, bold: true),
-            new XlsxFill(Color.FromArgb(0, 0x45, 0x86)),
-            XlsxBorder.None,
-            XlsxNumberFormat.General,
-            XlsxAlignment.Default);
-
-        xlsxWriter.BeginWorksheet("Sheet1", 1, 1);
-        xlsxWriter.BeginRow();
-        for (var j = 0; j < ColumnCount; j++)
-            xlsxWriter.Write($"Column {j}", headerStyle);
-        var colorIndex = 0;
-        for (var i = 0; i < RowCount; i++)
+        public static void Run()
         {
-            xlsxWriter.BeginRow().Write($"Row {i}");
-            for (var j = 1; j < 180; j++)
+            var stopwatch = Stopwatch.StartNew();
+            DoRun(requireCellReferences: true);
+            stopwatch.Stop();
+            Console.WriteLine(
+                $"{nameof(StyledLargeCreateStyles)} requiring references completed {RowCount} rows, {ColumnCount} columns and {ColorCount} colors in {stopwatch.ElapsedMilliseconds} ms.");
+
+            stopwatch.Restart();
+            DoRun(requireCellReferences: false);
+            stopwatch.Stop();
+            Console.WriteLine(
+                $"{nameof(StyledLargeCreateStyles)} omitting references completed {RowCount} rows, {ColumnCount} columns and {ColorCount} colors in {stopwatch.ElapsedMilliseconds} ms.");
+        }
+
+        private static void DoRun(bool requireCellReferences)
+        {
+            var rnd = new Random();
+            using (var stream = new FileStream($"{nameof(StyledLargeCreateStyles)}_{requireCellReferences}.xlsx",
+                       FileMode.Create, FileAccess.Write))
             {
-                xlsxWriter.Write(i * ColumnCount + j, XlsxStyle.Default.With(new XlsxFill(colors[colorIndex])));
-                colorIndex = (colorIndex + 1) % colors.Count;
+                using (var xlsxWriter = new XlsxWriter(stream, requireCellReferences: requireCellReferences))
+                {
+                    var colors = Enumerable.Repeat(0, 100)
+                        .Select(_ => Color.FromArgb(rnd.Next(256), rnd.Next(256), rnd.Next(256))).ToList();
+                    var headerStyle = new XlsxStyle(
+                        new XlsxFont("Calibri", 10.5, Color.White, bold: true),
+                        new XlsxFill(Color.FromArgb(0, 0x45, 0x86)),
+                        XlsxBorder.None,
+                        XlsxNumberFormat.General,
+                        XlsxAlignment.Default);
+
+                    xlsxWriter.BeginWorksheet("Sheet1", 1, 1);
+                    xlsxWriter.BeginRow();
+                    for (var j = 0; j < ColumnCount; j++)
+                        xlsxWriter.Write($"Column {j}", headerStyle);
+                    var colorIndex = 0;
+                    for (var i = 0; i < RowCount; i++)
+                    {
+                        xlsxWriter.BeginRow().Write($"Row {i}");
+                        for (var j = 1; j < 180; j++)
+                        {
+                            xlsxWriter.Write(i * ColumnCount + j,
+                                XlsxStyle.Default.With(new XlsxFill(colors[colorIndex])));
+                            colorIndex = (colorIndex + 1) % colors.Count;
+                        }
+                    }
+                }
             }
         }
     }

--- a/Examples/WorksheetVisibility.cs
+++ b/Examples/WorksheetVisibility.cs
@@ -27,20 +27,24 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 using System.IO;
 using LargeXlsx;
 
-namespace Examples;
-
-public static class WorksheetVisibility
+namespace Examples
 {
-    public static void Run()
+    public static class WorksheetVisibility
     {
-        using var stream = new FileStream($"{nameof(WorksheetVisibility)}.xlsx", FileMode.Create, FileAccess.Write);
-        using var xlsxWriter = new XlsxWriter(stream);
-        xlsxWriter
-            .BeginWorksheet("VisibleWorksheet")
-            .BeginRow().Write("A1").Write("B1")
-            .BeginWorksheet("HiddenWorksheet", state: XlsxWorksheetState.Hidden)
-            .BeginRow().Write("This sheet is hidden by default")
-            .BeginWorksheet("VeryHiddenWorksheet", state: XlsxWorksheetState.VeryHidden)
-            .BeginRow().Write("This sheet is veryHidden");
+        public static void Run()
+        {
+            using (var stream =
+                   new FileStream($"{nameof(WorksheetVisibility)}.xlsx", FileMode.Create, FileAccess.Write))
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                    xlsxWriter
+                        .BeginWorksheet("VisibleWorksheet")
+                        .BeginRow().Write("A1").Write("B1")
+                        .BeginWorksheet("HiddenWorksheet", state: XlsxWorksheetState.Hidden)
+                        .BeginRow().Write("This sheet is hidden by default")
+                        .BeginWorksheet("VeryHiddenWorksheet", state: XlsxWorksheetState.VeryHidden)
+                        .BeginRow().Write("This sheet is veryHidden");
+            }
+        }
     }
 }

--- a/Examples/Zip64Huge.cs
+++ b/Examples/Zip64Huge.cs
@@ -30,33 +30,38 @@ using System.IO;
 using LargeXlsx;
 using SharpCompress.Compressors.Deflate;
 
-namespace Examples;
-
-public static class Zip64Huge
+namespace Examples
 {
-    private const int RowCount = 1000000;
-    private const int ColumnCount = 200;
-
-    public static void Run()
+    public static class Zip64Huge
     {
-        var stopwatch = Stopwatch.StartNew();
-        using (var stream = new FileStream($"{nameof(Zip64Huge)}.xlsx", FileMode.Create, FileAccess.Write))
-        using (var xlsxWriter = new XlsxWriter(stream, compressionLevel: CompressionLevel.BestSpeed, useZip64: true))
+        private const int RowCount = 1000000;
+        private const int ColumnCount = 200;
+
+        public static void Run()
         {
-            xlsxWriter.BeginWorksheet("Sheet1", 1, 1);
-            xlsxWriter.BeginRow();
-            for (var j = 0; j < ColumnCount; j++)
-                xlsxWriter.Write($"Column {j}");
-            for (var i = 0; i < RowCount; i++)
+            var stopwatch = Stopwatch.StartNew();
+            using (var stream = new FileStream($"{nameof(Zip64Huge)}.xlsx", FileMode.Create, FileAccess.Write))
+            using (var xlsxWriter =
+                   new XlsxWriter(stream, compressionLevel: CompressionLevel.BestSpeed, useZip64: true))
             {
-                xlsxWriter.BeginRow().Write($"Row {i}");
-                for (var j = 1; j < ColumnCount; j++)
-                    xlsxWriter.Write(i * 100 + j);
-                if (i % 50000 == 0)
-                    Console.WriteLine($"{nameof(Zip64Huge)} wrote {i} rows in {stopwatch.ElapsedMilliseconds} ms...");
+                xlsxWriter.BeginWorksheet("Sheet1", 1, 1);
+                xlsxWriter.BeginRow();
+                for (var j = 0; j < ColumnCount; j++)
+                    xlsxWriter.Write($"Column {j}");
+                for (var i = 0; i < RowCount; i++)
+                {
+                    xlsxWriter.BeginRow().Write($"Row {i}");
+                    for (var j = 1; j < ColumnCount; j++)
+                        xlsxWriter.Write(i * 100 + j);
+                    if (i % 50000 == 0)
+                        Console.WriteLine(
+                            $"{nameof(Zip64Huge)} wrote {i} rows in {stopwatch.ElapsedMilliseconds} ms...");
+                }
             }
+
+            stopwatch.Stop();
+            Console.WriteLine(
+                $"{nameof(Zip64Huge)} completed {RowCount} rows and {ColumnCount} columns in {stopwatch.ElapsedMilliseconds} ms.");
         }
-        stopwatch.Stop();
-        Console.WriteLine($"{nameof(Zip64Huge)} completed {RowCount} rows and {ColumnCount} columns in {stopwatch.ElapsedMilliseconds} ms.");
     }
 }

--- a/Examples/Zip64Small.cs
+++ b/Examples/Zip64Small.cs
@@ -28,14 +28,21 @@ using System.IO;
 using LargeXlsx;
 using SharpCompress.Compressors.Deflate;
 
-namespace Examples;
-
-public static class Zip64Small
+namespace Examples
 {
-    public static void Run()
+    public static class Zip64Small
     {
-        using var stream = new FileStream($"{nameof(Zip64Small)}.xlsx", FileMode.Create, FileAccess.Write);
-        using var xlsxWriter = new XlsxWriter(stream, compressionLevel: CompressionLevel.BestSpeed, useZip64: true);
-        xlsxWriter.BeginWorksheet("Sheet1").BeginRow().Write("A1").Write("B1").BeginRow().Write("A2").Write("B2");
+        public static void Run()
+        {
+            using (var stream = new FileStream($"{nameof(Zip64Small)}.xlsx", FileMode.Create, FileAccess.Write))
+            {
+                using (var xlsxWriter =
+                       new XlsxWriter(stream, compressionLevel: CompressionLevel.BestSpeed, useZip64: true))
+                {
+                    xlsxWriter.BeginWorksheet("Sheet1").BeginRow().Write("A1").Write("B1").BeginRow().Write("A2")
+                        .Write("B2");
+                }
+            }
+        }
     }
 }

--- a/LargeXlsx.Tests/AlignmentTest.cs
+++ b/LargeXlsx.Tests/AlignmentTest.cs
@@ -52,7 +52,10 @@ namespace LargeXlsx.Tests
                     xlsxWriter.BeginWorksheet("Sheet 1").BeginRow()
                         .Write("Test", XlsxStyle.Default.With(new XlsxAlignment(horizontal: alignment)));
                 using (var package = new ExcelPackage(stream))
-                    package.Workbook.Worksheets[0].Cells["A1"].Style.HorizontalAlignment.ShouldBe(expected);
+                {
+                    var worksheetIndex = package.Compatibility.IsWorksheets1Based ? 1 : 0;
+                    package.Workbook.Worksheets[worksheetIndex].Cells["A1"].Style.HorizontalAlignment.ShouldBe(expected);
+                }
             }
         }
 
@@ -69,7 +72,10 @@ namespace LargeXlsx.Tests
                     xlsxWriter.BeginWorksheet("Sheet 1").BeginRow()
                         .Write("Test", XlsxStyle.Default.With(new XlsxAlignment(vertical: alignment)));
                 using (var package = new ExcelPackage(stream))
-                    package.Workbook.Worksheets[0].Cells["A1"].Style.VerticalAlignment.ShouldBe(expected);
+                {
+                    var worksheetIndex = package.Compatibility.IsWorksheets1Based ? 1 : 0;
+                    package.Workbook.Worksheets[worksheetIndex].Cells["A1"].Style.VerticalAlignment.ShouldBe(expected);
+                }
             }
         }
 
@@ -82,7 +88,10 @@ namespace LargeXlsx.Tests
                     xlsxWriter.BeginWorksheet("Sheet 1").BeginRow()
                         .Write("Test", XlsxStyle.Default.With(new XlsxAlignment(textRotation: 45)));
                 using (var package = new ExcelPackage(stream))
-                    package.Workbook.Worksheets[0].Cells["A1"].Style.TextRotation.ShouldBe(45);
+                {
+                    var worksheetIndex = package.Compatibility.IsWorksheets1Based ? 1 : 0;
+                    package.Workbook.Worksheets[worksheetIndex].Cells["A1"].Style.TextRotation.ShouldBe(45);
+                }
             }
         }
 
@@ -95,7 +104,10 @@ namespace LargeXlsx.Tests
                     xlsxWriter.BeginWorksheet("Sheet 1").BeginRow()
                         .Write("Test", XlsxStyle.Default.With(new XlsxAlignment(indent: 2)));
                 using (var package = new ExcelPackage(stream))
-                    package.Workbook.Worksheets[0].Cells["A1"].Style.Indent.ShouldBe(2);
+                {
+                    var worksheetIndex = package.Compatibility.IsWorksheets1Based ? 1 : 0;
+                    package.Workbook.Worksheets[worksheetIndex].Cells["A1"].Style.Indent.ShouldBe(2);
+                }
             }
         }
 
@@ -108,7 +120,10 @@ namespace LargeXlsx.Tests
                     xlsxWriter.BeginWorksheet("Sheet 1").BeginRow()
                         .Write("Test", XlsxStyle.Default.With(new XlsxAlignment(wrapText: true)));
                 using (var package = new ExcelPackage(stream))
-                    package.Workbook.Worksheets[0].Cells["A1"].Style.WrapText.ShouldBe(true);
+                {
+                    var worksheetIndex = package.Compatibility.IsWorksheets1Based ? 1 : 0;
+                    package.Workbook.Worksheets[worksheetIndex].Cells["A1"].Style.WrapText.ShouldBe(true);
+                }
             }
         }
 
@@ -121,7 +136,10 @@ namespace LargeXlsx.Tests
                     xlsxWriter.BeginWorksheet("Sheet 1").BeginRow()
                         .Write("Test", XlsxStyle.Default.With(new XlsxAlignment(shrinkToFit: true)));
                 using (var package = new ExcelPackage(stream))
-                    package.Workbook.Worksheets[0].Cells["A1"].Style.ShrinkToFit.ShouldBe(true);
+                {
+                    var worksheetIndex = package.Compatibility.IsWorksheets1Based ? 1 : 0;
+                    package.Workbook.Worksheets[worksheetIndex].Cells["A1"].Style.ShrinkToFit.ShouldBe(true);
+                }
             }
         }
 
@@ -136,7 +154,10 @@ namespace LargeXlsx.Tests
                     xlsxWriter.BeginWorksheet("Sheet 1").BeginRow()
                         .Write("Test", XlsxStyle.Default.With(new XlsxAlignment(readingOrder: readingOrder)));
                 using (var package = new ExcelPackage(stream))
-                    package.Workbook.Worksheets[0].Cells["A1"].Style.ReadingOrder.ShouldBe(expected);
+                {
+                    var worksheetIndex = package.Compatibility.IsWorksheets1Based ? 1 : 0;
+                    package.Workbook.Worksheets[worksheetIndex].Cells["A1"].Style.ReadingOrder.ShouldBe(expected);
+                }
             }
         }
 
@@ -146,18 +167,13 @@ namespace LargeXlsx.Tests
             using (var stream = new MemoryStream())
             {
                 using (var xlsxWriter = new XlsxWriter(stream))
-                {
                     xlsxWriter.BeginWorksheet("Sheet 1").BeginRow().Write("Test");
-                }
-
-                stream.Flush();
-                stream.Position = 0; // <-- Add this line
-
+                
                 using (var package = new ExcelPackage(stream))
                 {
-                    var count = package.Workbook.Worksheets.Count;
+                    var worksheetIndex = package.Compatibility.IsWorksheets1Based ? 1 : 0;
 
-                    var style = package.Workbook.Worksheets[0].Cells["A1"].Style;
+                    var style = package.Workbook.Worksheets[worksheetIndex].Cells["A1"].Style;
                     style.HorizontalAlignment.ShouldBe(ExcelHorizontalAlignment.General);
                     style.VerticalAlignment.ShouldBe(ExcelVerticalAlignment.Bottom);
                     style.ShrinkToFit.ShouldBeFalse();

--- a/LargeXlsx.Tests/AlignmentTest.cs
+++ b/LargeXlsx.Tests/AlignmentTest.cs
@@ -30,117 +30,143 @@ using OfficeOpenXml;
 using OfficeOpenXml.Style;
 using Shouldly;
 
-namespace LargeXlsx.Tests;
-
-[TestFixture]
-public static class AlignmentTest
+namespace LargeXlsx.Tests
 {
-    [TestCase(XlsxAlignment.Horizontal.General, ExcelHorizontalAlignment.General)]
-    [TestCase(XlsxAlignment.Horizontal.Left, ExcelHorizontalAlignment.Left)]
-    [TestCase(XlsxAlignment.Horizontal.Center, ExcelHorizontalAlignment.Center)]
-    [TestCase(XlsxAlignment.Horizontal.Right, ExcelHorizontalAlignment.Right)]
-    [TestCase(XlsxAlignment.Horizontal.Fill, ExcelHorizontalAlignment.Fill)]
-    [TestCase(XlsxAlignment.Horizontal.Justify, ExcelHorizontalAlignment.Justify)]
-    [TestCase(XlsxAlignment.Horizontal.CenterContinuous, ExcelHorizontalAlignment.CenterContinuous)]
-    [TestCase(XlsxAlignment.Horizontal.Distributed, ExcelHorizontalAlignment.Distributed)]
-    public static void HorizontalAlignment(XlsxAlignment.Horizontal alignment, ExcelHorizontalAlignment expected)
-    {
-        using var stream = new MemoryStream();
-        using (var xlsxWriter = new XlsxWriter(stream))
-            xlsxWriter.BeginWorksheet("Sheet 1").BeginRow()
-                .Write("Test", XlsxStyle.Default.With(new XlsxAlignment(horizontal: alignment)));
-        using (var package = new ExcelPackage(stream))
-            package.Workbook.Worksheets[0].Cells["A1"].Style.HorizontalAlignment.ShouldBe(expected);
-    }
 
-    [TestCase(XlsxAlignment.Vertical.Top, ExcelVerticalAlignment.Top)]
-    [TestCase(XlsxAlignment.Vertical.Center, ExcelVerticalAlignment.Center)]
-    [TestCase(XlsxAlignment.Vertical.Bottom, ExcelVerticalAlignment.Bottom)]
-    [TestCase(XlsxAlignment.Vertical.Justify, ExcelVerticalAlignment.Justify)]
-    [TestCase(XlsxAlignment.Vertical.Distributed, ExcelVerticalAlignment.Distributed)]
-    public static void VerticalAlignment(XlsxAlignment.Vertical alignment, ExcelVerticalAlignment expected)
+    [TestFixture]
+    public static class AlignmentTest
     {
-        using var stream = new MemoryStream();
-        using (var xlsxWriter = new XlsxWriter(stream))
-            xlsxWriter.BeginWorksheet("Sheet 1").BeginRow()
-                .Write("Test", XlsxStyle.Default.With(new XlsxAlignment(vertical: alignment)));
-        using (var package = new ExcelPackage(stream))
-            package.Workbook.Worksheets[0].Cells["A1"].Style.VerticalAlignment.ShouldBe(expected);
-    }
-
-    [Test]
-    public static void TextRotation()
-    {
-        using var stream = new MemoryStream();
-        using (var xlsxWriter = new XlsxWriter(stream))
-            xlsxWriter.BeginWorksheet("Sheet 1").BeginRow()
-                .Write("Test", XlsxStyle.Default.With(new XlsxAlignment(textRotation: 45)));
-        using (var package = new ExcelPackage(stream))
-            package.Workbook.Worksheets[0].Cells["A1"].Style.TextRotation.ShouldBe(45);
-    }
-
-    [Test]
-    public static void Indent()
-    {
-        using var stream = new MemoryStream();
-        using (var xlsxWriter = new XlsxWriter(stream))
-            xlsxWriter.BeginWorksheet("Sheet 1").BeginRow()
-                .Write("Test", XlsxStyle.Default.With(new XlsxAlignment(indent: 2)));
-        using (var package = new ExcelPackage(stream))
-            package.Workbook.Worksheets[0].Cells["A1"].Style.Indent.ShouldBe(2);
-    }
-
-    [Test]
-    public static void WrapText()
-    {
-        using var stream = new MemoryStream();
-        using (var xlsxWriter = new XlsxWriter(stream))
-            xlsxWriter.BeginWorksheet("Sheet 1").BeginRow()
-                .Write("Test", XlsxStyle.Default.With(new XlsxAlignment(wrapText: true)));
-        using (var package = new ExcelPackage(stream))
-            package.Workbook.Worksheets[0].Cells["A1"].Style.WrapText.ShouldBe(true);
-    }
-
-    [Test]
-    public static void ShrinkToFit()
-    {
-        using var stream = new MemoryStream();
-        using (var xlsxWriter = new XlsxWriter(stream))
-            xlsxWriter.BeginWorksheet("Sheet 1").BeginRow()
-                .Write("Test", XlsxStyle.Default.With(new XlsxAlignment(shrinkToFit: true)));
-        using (var package = new ExcelPackage(stream))
-            package.Workbook.Worksheets[0].Cells["A1"].Style.ShrinkToFit.ShouldBe(true);
-    }
-
-    [TestCase(XlsxAlignment.ReadingOrder.ContextDependent, ExcelReadingOrder.ContextDependent)]
-    [TestCase(XlsxAlignment.ReadingOrder.LeftToRight, ExcelReadingOrder.LeftToRight)]
-    [TestCase(XlsxAlignment.ReadingOrder.RightToLeft, ExcelReadingOrder.RightToLeft)]
-    public static void ReadingOrder(XlsxAlignment.ReadingOrder readingOrder, ExcelReadingOrder expected)
-    {
-        using var stream = new MemoryStream();
-        using (var xlsxWriter = new XlsxWriter(stream))
-            xlsxWriter.BeginWorksheet("Sheet 1").BeginRow()
-                .Write("Test", XlsxStyle.Default.With(new XlsxAlignment(readingOrder: readingOrder)));
-        using (var package = new ExcelPackage(stream))
-            package.Workbook.Worksheets[0].Cells["A1"].Style.ReadingOrder.ShouldBe(expected);
-    }
-
-    [Test]
-    public static void Defaults()
-    {
-        using var stream = new MemoryStream();
-        using (var xlsxWriter = new XlsxWriter(stream))
-            xlsxWriter.BeginWorksheet("Sheet 1").BeginRow().Write("Test");
-        using (var package = new ExcelPackage(stream))
+        [TestCase(XlsxAlignment.Horizontal.General, ExcelHorizontalAlignment.General)]
+        [TestCase(XlsxAlignment.Horizontal.Left, ExcelHorizontalAlignment.Left)]
+        [TestCase(XlsxAlignment.Horizontal.Center, ExcelHorizontalAlignment.Center)]
+        [TestCase(XlsxAlignment.Horizontal.Right, ExcelHorizontalAlignment.Right)]
+        [TestCase(XlsxAlignment.Horizontal.Fill, ExcelHorizontalAlignment.Fill)]
+        [TestCase(XlsxAlignment.Horizontal.Justify, ExcelHorizontalAlignment.Justify)]
+        [TestCase(XlsxAlignment.Horizontal.CenterContinuous, ExcelHorizontalAlignment.CenterContinuous)]
+        [TestCase(XlsxAlignment.Horizontal.Distributed, ExcelHorizontalAlignment.Distributed)]
+        public static void HorizontalAlignment(XlsxAlignment.Horizontal alignment, ExcelHorizontalAlignment expected)
         {
-            var style = package.Workbook.Worksheets[0].Cells["A1"].Style;
-            style.HorizontalAlignment.ShouldBe(ExcelHorizontalAlignment.General);
-            style.VerticalAlignment.ShouldBe(ExcelVerticalAlignment.Bottom);
-            style.ShrinkToFit.ShouldBeFalse();
-            style.WrapText.ShouldBeFalse();
-            style.TextRotation.ShouldBe(0);
-            style.Indent.ShouldBe(0);
-            style.ReadingOrder.ShouldBe(ExcelReadingOrder.ContextDependent);
+            using (var stream = new MemoryStream())
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                    xlsxWriter.BeginWorksheet("Sheet 1").BeginRow()
+                        .Write("Test", XlsxStyle.Default.With(new XlsxAlignment(horizontal: alignment)));
+                using (var package = new ExcelPackage(stream))
+                    package.Workbook.Worksheets[0].Cells["A1"].Style.HorizontalAlignment.ShouldBe(expected);
+            }
+        }
+
+        [TestCase(XlsxAlignment.Vertical.Top, ExcelVerticalAlignment.Top)]
+        [TestCase(XlsxAlignment.Vertical.Center, ExcelVerticalAlignment.Center)]
+        [TestCase(XlsxAlignment.Vertical.Bottom, ExcelVerticalAlignment.Bottom)]
+        [TestCase(XlsxAlignment.Vertical.Justify, ExcelVerticalAlignment.Justify)]
+        [TestCase(XlsxAlignment.Vertical.Distributed, ExcelVerticalAlignment.Distributed)]
+        public static void VerticalAlignment(XlsxAlignment.Vertical alignment, ExcelVerticalAlignment expected)
+        {
+            using (var stream = new MemoryStream())
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                    xlsxWriter.BeginWorksheet("Sheet 1").BeginRow()
+                        .Write("Test", XlsxStyle.Default.With(new XlsxAlignment(vertical: alignment)));
+                using (var package = new ExcelPackage(stream))
+                    package.Workbook.Worksheets[0].Cells["A1"].Style.VerticalAlignment.ShouldBe(expected);
+            }
+        }
+
+        [Test]
+        public static void TextRotation()
+        {
+            using (var stream = new MemoryStream())
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                    xlsxWriter.BeginWorksheet("Sheet 1").BeginRow()
+                        .Write("Test", XlsxStyle.Default.With(new XlsxAlignment(textRotation: 45)));
+                using (var package = new ExcelPackage(stream))
+                    package.Workbook.Worksheets[0].Cells["A1"].Style.TextRotation.ShouldBe(45);
+            }
+        }
+
+        [Test]
+        public static void Indent()
+        {
+            using (var stream = new MemoryStream())
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                    xlsxWriter.BeginWorksheet("Sheet 1").BeginRow()
+                        .Write("Test", XlsxStyle.Default.With(new XlsxAlignment(indent: 2)));
+                using (var package = new ExcelPackage(stream))
+                    package.Workbook.Worksheets[0].Cells["A1"].Style.Indent.ShouldBe(2);
+            }
+        }
+
+        [Test]
+        public static void WrapText()
+        {
+            using (var stream = new MemoryStream())
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                    xlsxWriter.BeginWorksheet("Sheet 1").BeginRow()
+                        .Write("Test", XlsxStyle.Default.With(new XlsxAlignment(wrapText: true)));
+                using (var package = new ExcelPackage(stream))
+                    package.Workbook.Worksheets[0].Cells["A1"].Style.WrapText.ShouldBe(true);
+            }
+        }
+
+        [Test]
+        public static void ShrinkToFit()
+        {
+            using (var stream = new MemoryStream())
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                    xlsxWriter.BeginWorksheet("Sheet 1").BeginRow()
+                        .Write("Test", XlsxStyle.Default.With(new XlsxAlignment(shrinkToFit: true)));
+                using (var package = new ExcelPackage(stream))
+                    package.Workbook.Worksheets[0].Cells["A1"].Style.ShrinkToFit.ShouldBe(true);
+            }
+        }
+
+        [TestCase(XlsxAlignment.ReadingOrder.ContextDependent, ExcelReadingOrder.ContextDependent)]
+        [TestCase(XlsxAlignment.ReadingOrder.LeftToRight, ExcelReadingOrder.LeftToRight)]
+        [TestCase(XlsxAlignment.ReadingOrder.RightToLeft, ExcelReadingOrder.RightToLeft)]
+        public static void ReadingOrder(XlsxAlignment.ReadingOrder readingOrder, ExcelReadingOrder expected)
+        {
+            using (var stream = new MemoryStream())
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                    xlsxWriter.BeginWorksheet("Sheet 1").BeginRow()
+                        .Write("Test", XlsxStyle.Default.With(new XlsxAlignment(readingOrder: readingOrder)));
+                using (var package = new ExcelPackage(stream))
+                    package.Workbook.Worksheets[0].Cells["A1"].Style.ReadingOrder.ShouldBe(expected);
+            }
+        }
+
+        [Test]
+        public static void Defaults()
+        {
+            using (var stream = new MemoryStream())
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                {
+                    xlsxWriter.BeginWorksheet("Sheet 1").BeginRow().Write("Test");
+                }
+
+                stream.Flush();
+                stream.Position = 0; // <-- Add this line
+
+                using (var package = new ExcelPackage(stream))
+                {
+                    var count = package.Workbook.Worksheets.Count;
+
+                    var style = package.Workbook.Worksheets[0].Cells["A1"].Style;
+                    style.HorizontalAlignment.ShouldBe(ExcelHorizontalAlignment.General);
+                    style.VerticalAlignment.ShouldBe(ExcelVerticalAlignment.Bottom);
+                    style.ShrinkToFit.ShouldBeFalse();
+                    style.WrapText.ShouldBeFalse();
+                    style.TextRotation.ShouldBe(0);
+                    style.Indent.ShouldBe(0);
+                    style.ReadingOrder.ShouldBe(ExcelReadingOrder.ContextDependent);
+                }
+            }
         }
     }
 }

--- a/LargeXlsx.Tests/BorderTest.cs
+++ b/LargeXlsx.Tests/BorderTest.cs
@@ -62,7 +62,8 @@ namespace LargeXlsx.Tests
                                 new XlsxBorder(top: new XlsxBorder.Line(Color.DeepPink, borderStyle))));
                 using (var package = new ExcelPackage(stream))
                 {
-                    var border = package.Workbook.Worksheets[0].Cells["A1"].Style.Border;
+                    var worksheetIndex = package.Compatibility.IsWorksheets1Based ? 1 : 0;
+                    var border = package.Workbook.Worksheets[worksheetIndex].Cells["A1"].Style.Border;
                     border.Top.Color.Rgb.ShouldBe("FFFF1493");
                     border.Top.Style.ShouldBe(expected);
                 }
@@ -79,7 +80,8 @@ namespace LargeXlsx.Tests
                     xlsxWriter.BeginWorksheet("Sheet 1").BeginRow().Write("Test");
                 using (var package = new ExcelPackage(stream))
                 {
-                    var style = package.Workbook.Worksheets[0].Cells["A1"].Style;
+                    var worksheetIndex = package.Compatibility.IsWorksheets1Based ? 1 : 0;
+                    var style = package.Workbook.Worksheets[worksheetIndex].Cells["A1"].Style;
                     style.Border.Top.Color.Rgb.ShouldBeNull();
                     style.Border.Top.Style.ShouldBe(ExcelBorderStyle.None);
                     style.Border.Right.Color.Rgb.ShouldBeNull();

--- a/LargeXlsx.Tests/BorderTest.cs
+++ b/LargeXlsx.Tests/BorderTest.cs
@@ -31,56 +31,69 @@ using OfficeOpenXml;
 using OfficeOpenXml.Style;
 using Shouldly;
 
-namespace LargeXlsx.Tests;
 
-[TestFixture]
-public static class BorderTest
+namespace LargeXlsx.Tests
 {
-    [TestCase(XlsxBorder.Style.None, ExcelBorderStyle.None)]
-    [TestCase(XlsxBorder.Style.Thin, ExcelBorderStyle.Thin)]
-    [TestCase(XlsxBorder.Style.Medium, ExcelBorderStyle.Medium)]
-    [TestCase(XlsxBorder.Style.Dashed, ExcelBorderStyle.Dashed)]
-    [TestCase(XlsxBorder.Style.Dotted, ExcelBorderStyle.Dotted)]
-    [TestCase(XlsxBorder.Style.Thick, ExcelBorderStyle.Thick)]
-    [TestCase(XlsxBorder.Style.Double, ExcelBorderStyle.Double)]
-    [TestCase(XlsxBorder.Style.Hair, ExcelBorderStyle.Hair)]
-    [TestCase(XlsxBorder.Style.MediumDashed, ExcelBorderStyle.MediumDashed)]
-    [TestCase(XlsxBorder.Style.DashDot, ExcelBorderStyle.DashDot)]
-    [TestCase(XlsxBorder.Style.MediumDashDot, ExcelBorderStyle.MediumDashDot)]
-    [TestCase(XlsxBorder.Style.DashDotDot, ExcelBorderStyle.DashDotDot)]
-    [TestCase(XlsxBorder.Style.MediumDashDotDot, ExcelBorderStyle.MediumDashDotDot)]
-    public static void HorizontalAlignment(XlsxBorder.Style borderStyle, ExcelBorderStyle expected)
+
+    [TestFixture]
+    public static class BorderTest
     {
-        using var stream = new MemoryStream();
-        using (var xlsxWriter = new XlsxWriter(stream))
-            xlsxWriter.BeginWorksheet("Sheet 1").BeginRow()
-                .Write("Test", XlsxStyle.Default.With(new XlsxBorder(top: new XlsxBorder.Line(Color.DeepPink, borderStyle))));
-        using var package = new ExcelPackage(stream);
-        var border = package.Workbook.Worksheets[0].Cells["A1"].Style.Border;
-        border.Top.Color.Rgb.ShouldBe("FFFF1493");
-        border.Top.Style.ShouldBe(expected);
-    }
+        [TestCase(XlsxBorder.Style.None, ExcelBorderStyle.None)]
+        [TestCase(XlsxBorder.Style.Thin, ExcelBorderStyle.Thin)]
+        [TestCase(XlsxBorder.Style.Medium, ExcelBorderStyle.Medium)]
+        [TestCase(XlsxBorder.Style.Dashed, ExcelBorderStyle.Dashed)]
+        [TestCase(XlsxBorder.Style.Dotted, ExcelBorderStyle.Dotted)]
+        [TestCase(XlsxBorder.Style.Thick, ExcelBorderStyle.Thick)]
+        [TestCase(XlsxBorder.Style.Double, ExcelBorderStyle.Double)]
+        [TestCase(XlsxBorder.Style.Hair, ExcelBorderStyle.Hair)]
+        [TestCase(XlsxBorder.Style.MediumDashed, ExcelBorderStyle.MediumDashed)]
+        [TestCase(XlsxBorder.Style.DashDot, ExcelBorderStyle.DashDot)]
+        [TestCase(XlsxBorder.Style.MediumDashDot, ExcelBorderStyle.MediumDashDot)]
+        [TestCase(XlsxBorder.Style.DashDotDot, ExcelBorderStyle.DashDotDot)]
+        [TestCase(XlsxBorder.Style.MediumDashDotDot, ExcelBorderStyle.MediumDashDotDot)]
+        public static void HorizontalAlignment(XlsxBorder.Style borderStyle, ExcelBorderStyle expected)
+        {
+            using (var stream = new MemoryStream())
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                    xlsxWriter.BeginWorksheet("Sheet 1").BeginRow()
+                        .Write("Test",
+                            XlsxStyle.Default.With(
+                                new XlsxBorder(top: new XlsxBorder.Line(Color.DeepPink, borderStyle))));
+                using (var package = new ExcelPackage(stream))
+                {
+                    var border = package.Workbook.Worksheets[0].Cells["A1"].Style.Border;
+                    border.Top.Color.Rgb.ShouldBe("FFFF1493");
+                    border.Top.Style.ShouldBe(expected);
+                }
+            }
+        }
 
 
-    [Test]
-    public static void Defaults()
-    {
-        using var stream = new MemoryStream();
-        using (var xlsxWriter = new XlsxWriter(stream))
-            xlsxWriter.BeginWorksheet("Sheet 1").BeginRow().Write("Test");
-        using var package = new ExcelPackage(stream);
-        var style = package.Workbook.Worksheets[0].Cells["A1"].Style;
-        style.Border.Top.Color.Rgb.ShouldBeNull();
-        style.Border.Top.Style.ShouldBe(ExcelBorderStyle.None);
-        style.Border.Right.Color.Rgb.ShouldBeNull();
-        style.Border.Right.Style.ShouldBe(ExcelBorderStyle.None);
-        style.Border.Bottom.Color.Rgb.ShouldBeNull();
-        style.Border.Bottom.Style.ShouldBe(ExcelBorderStyle.None);
-        style.Border.Left.Color.Rgb.ShouldBeNull();
-        style.Border.Left.Style.ShouldBe(ExcelBorderStyle.None);
-        style.Border.Diagonal.Color.Rgb.ShouldBeNull();
-        style.Border.Diagonal.Style.ShouldBe(ExcelBorderStyle.None);
-        style.Border.DiagonalDown.ShouldBeFalse();
-        style.Border.DiagonalUp.ShouldBeFalse();
+        [Test]
+        public static void Defaults()
+        {
+            using (var stream = new MemoryStream())
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                    xlsxWriter.BeginWorksheet("Sheet 1").BeginRow().Write("Test");
+                using (var package = new ExcelPackage(stream))
+                {
+                    var style = package.Workbook.Worksheets[0].Cells["A1"].Style;
+                    style.Border.Top.Color.Rgb.ShouldBeNull();
+                    style.Border.Top.Style.ShouldBe(ExcelBorderStyle.None);
+                    style.Border.Right.Color.Rgb.ShouldBeNull();
+                    style.Border.Right.Style.ShouldBe(ExcelBorderStyle.None);
+                    style.Border.Bottom.Color.Rgb.ShouldBeNull();
+                    style.Border.Bottom.Style.ShouldBe(ExcelBorderStyle.None);
+                    style.Border.Left.Color.Rgb.ShouldBeNull();
+                    style.Border.Left.Style.ShouldBe(ExcelBorderStyle.None);
+                    style.Border.Diagonal.Color.Rgb.ShouldBeNull();
+                    style.Border.Diagonal.Style.ShouldBe(ExcelBorderStyle.None);
+                    style.Border.DiagonalDown.ShouldBeFalse();
+                    style.Border.DiagonalUp.ShouldBeFalse();
+                }
+            }
+        }
     }
 }

--- a/LargeXlsx.Tests/ColumnFormattingTest.cs
+++ b/LargeXlsx.Tests/ColumnFormattingTest.cs
@@ -34,77 +34,103 @@ using OfficeOpenXml.Style;
 using Shouldly;
 using Color = System.Drawing.Color;
 
-namespace LargeXlsx.Tests;
 
-[TestFixture]
-public static class ColumnFormattingTest
+namespace LargeXlsx.Tests
 {
-    [Test]
-    public static void Width()
+    [TestFixture]
+    public static class ColumnFormattingTest
     {
-        using var stream = new MemoryStream();
-        using (var xlsxWriter = new XlsxWriter(stream))
-            xlsxWriter.BeginWorksheet("Sheet 1", columns: new[] { XlsxColumn.Formatted(width: 20) });
-        using (var package = new ExcelPackage(stream))
-            package.Workbook.Worksheets[0].Column(1).Width.ShouldBe(20);
-    }
-
-    [Test]
-    public static void Style()
-    {
-        var blueStyle = new XlsxStyle(XlsxFont.Default.With(Color.White), new XlsxFill(Color.FromArgb(0, 0x45, 0x86)), XlsxBorder.None, XlsxNumberFormat.General, XlsxAlignment.Default);
-        using var stream = new MemoryStream();
-        using (var xlsxWriter = new XlsxWriter(stream))
-            xlsxWriter.BeginWorksheet("Sheet 1", columns: new[] { XlsxColumn.Formatted(width: 20, style: blueStyle) });
-        using var package = new ExcelPackage(stream);
-        var style = package.Workbook.Worksheets[0].Column(1).Style;
-        style.Fill.PatternType.ShouldBe(ExcelFillStyle.Solid);
-        style.Fill.BackgroundColor.Rgb.ShouldBe("FF004586");
-        style.Font.Color.Rgb.ShouldBe("FFFFFFFF");
-    }
-
-    [Test]
-    public static void Hidden()
-    {
-        using var stream = new MemoryStream();
-        using (var xlsxWriter = new XlsxWriter(stream))
-            xlsxWriter.BeginWorksheet("Sheet 1", columns: new[] { XlsxColumn.Formatted(width: 0, hidden: true) });
-        using (var package = new ExcelPackage(stream))
-            package.Workbook.Worksheets[0].Column(1).Hidden.ShouldBeTrue();
-    }
-
-    [Test]
-    public static void SkipUnformatted()
-    {
-        using var stream = new MemoryStream();
-        using (var xlsxWriter = new XlsxWriter(stream))
-            xlsxWriter.BeginWorksheet("Sheet 1", columns: new[]
+        [Test]
+        public static void Width()
+        {
+            using (var stream = new MemoryStream())
             {
-                XlsxColumn.Formatted(count: 2, width: 0, hidden: true),
-                XlsxColumn.Unformatted(count: 3),
-                XlsxColumn.Formatted(count: 1, width: 0, hidden: true)
-            });
-        using var package = new ExcelPackage(stream);
-        var worksheet = package.Workbook.Worksheets[0];
-        worksheet.Column(1).Hidden.ShouldBeTrue();
-        worksheet.Column(2).Hidden.ShouldBeTrue();
-        worksheet.Column(3).Hidden.ShouldBeFalse();
-        worksheet.Column(4).Hidden.ShouldBeFalse();
-        worksheet.Column(5).Hidden.ShouldBeFalse();
-        worksheet.Column(6).Hidden.ShouldBeTrue();
-        worksheet.Column(7).Hidden.ShouldBeFalse();
-    }
+                using (var xlsxWriter = new XlsxWriter(stream))
+                    xlsxWriter.BeginWorksheet("Sheet 1", columns: new[] {XlsxColumn.Formatted(width: 20)});
+                using (var package = new ExcelPackage(stream))
+                    package.Workbook.Worksheets[0].Column(1).Width.ShouldBe(20);
+            }
+        }
 
-    [Test]
-    public static void OnlyUnformatted()
-    {
-        using var stream = new MemoryStream();
-        using (var xlsxWriter = new XlsxWriter(stream))
-            xlsxWriter.BeginWorksheet("Sheet 1", columns: new[] { XlsxColumn.Unformatted() });
+        [Test]
+        public static void Style()
+        {
+            var blueStyle = new XlsxStyle(XlsxFont.Default.With(Color.White),
+                new XlsxFill(Color.FromArgb(0, 0x45, 0x86)), XlsxBorder.None, XlsxNumberFormat.General,
+                XlsxAlignment.Default);
+            using (var stream = new MemoryStream())
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                    xlsxWriter.BeginWorksheet("Sheet 1",
+                        columns: new[] {XlsxColumn.Formatted(width: 20, style: blueStyle)});
+                using (var package = new ExcelPackage(stream))
+                {
+                    var style = package.Workbook.Worksheets[0].Column(1).Style;
+                    style.Fill.PatternType.ShouldBe(ExcelFillStyle.Solid);
+                    style.Fill.BackgroundColor.Rgb.ShouldBe("FF004586");
+                    style.Font.Color.Rgb.ShouldBe("FFFFFFFF");
+                }
+            }
+        }
 
-        using var spreadsheetDocument = SpreadsheetDocument.Open(stream, false);
-        var sheetId = spreadsheetDocument.WorkbookPart!.Workbook.Sheets!.Elements<Sheet>().Single(s => s.Name == "Sheet 1").Id!.ToString()!;
-        var worksheetPart = (WorksheetPart)spreadsheetDocument.WorkbookPart!.GetPartById(sheetId);
-        worksheetPart.Worksheet.Descendants<Columns>().ShouldBeEmpty();
+        [Test]
+        public static void Hidden()
+        {
+            using (var stream = new MemoryStream())
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                    xlsxWriter.BeginWorksheet("Sheet 1", columns: new[] {XlsxColumn.Formatted(width: 0, hidden: true)});
+                using (var package = new ExcelPackage(stream))
+                    package.Workbook.Worksheets[0].Column(1).Hidden.ShouldBeTrue();
+            }
+        }
+
+        [Test]
+        public static void SkipUnformatted()
+        {
+            using (var stream = new MemoryStream())
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                    xlsxWriter.BeginWorksheet("Sheet 1", columns: new[]
+                    {
+                        XlsxColumn.Formatted(count: 2, width: 0, hidden: true),
+                        XlsxColumn.Unformatted(count: 3),
+                        XlsxColumn.Formatted(count: 1, width: 0, hidden: true)
+                    });
+                using (var package = new ExcelPackage(stream))
+                {
+                    var worksheet = package.Workbook.Worksheets[0];
+                    worksheet.Column(1).Hidden.ShouldBeTrue();
+                    worksheet.Column(2).Hidden.ShouldBeTrue();
+                    worksheet.Column(3).Hidden.ShouldBeFalse();
+                    worksheet.Column(4).Hidden.ShouldBeFalse();
+                    worksheet.Column(5).Hidden.ShouldBeFalse();
+                    worksheet.Column(6).Hidden.ShouldBeTrue();
+                    worksheet.Column(7).Hidden.ShouldBeFalse();
+                }
+            }
+        }
+
+        [Test]
+        public static void OnlyUnformatted()
+        {
+            using (var stream = new MemoryStream())
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                    xlsxWriter.BeginWorksheet("Sheet 1", columns: new[] {XlsxColumn.Unformatted()});
+
+                using (var spreadsheetDocument = SpreadsheetDocument.Open(stream, false))
+                {
+                    var sheetId = spreadsheetDocument.WorkbookPart?.Workbook.Sheets?.Elements<Sheet>()
+                        .Single(s => s.Name == "Sheet 1").Id?.ToString();
+                    sheetId.ShouldNotBeNull();
+
+                    var worksheetPart = spreadsheetDocument.WorkbookPart?.GetPartById(sheetId) as WorksheetPart;
+                    worksheetPart.ShouldNotBeNull();
+
+                    worksheetPart.Worksheet.Descendants<Columns>().ShouldBeEmpty();
+                }
+            }
+        }
     }
 }

--- a/LargeXlsx.Tests/ColumnFormattingTest.cs
+++ b/LargeXlsx.Tests/ColumnFormattingTest.cs
@@ -48,7 +48,10 @@ namespace LargeXlsx.Tests
                 using (var xlsxWriter = new XlsxWriter(stream))
                     xlsxWriter.BeginWorksheet("Sheet 1", columns: new[] {XlsxColumn.Formatted(width: 20)});
                 using (var package = new ExcelPackage(stream))
-                    package.Workbook.Worksheets[0].Column(1).Width.ShouldBe(20);
+                {
+                    var worksheetIndex = package.Compatibility.IsWorksheets1Based ? 1 : 0;
+                    package.Workbook.Worksheets[worksheetIndex].Column(1).Width.ShouldBe(20);
+                }
             }
         }
 
@@ -65,7 +68,8 @@ namespace LargeXlsx.Tests
                         columns: new[] {XlsxColumn.Formatted(width: 20, style: blueStyle)});
                 using (var package = new ExcelPackage(stream))
                 {
-                    var style = package.Workbook.Worksheets[0].Column(1).Style;
+                    var worksheetIndex = package.Compatibility.IsWorksheets1Based ? 1 : 0;
+                    var style = package.Workbook.Worksheets[worksheetIndex].Column(1).Style;
                     style.Fill.PatternType.ShouldBe(ExcelFillStyle.Solid);
                     style.Fill.BackgroundColor.Rgb.ShouldBe("FF004586");
                     style.Font.Color.Rgb.ShouldBe("FFFFFFFF");
@@ -81,7 +85,10 @@ namespace LargeXlsx.Tests
                 using (var xlsxWriter = new XlsxWriter(stream))
                     xlsxWriter.BeginWorksheet("Sheet 1", columns: new[] {XlsxColumn.Formatted(width: 0, hidden: true)});
                 using (var package = new ExcelPackage(stream))
-                    package.Workbook.Worksheets[0].Column(1).Hidden.ShouldBeTrue();
+                {
+                    var worksheetIndex = package.Compatibility.IsWorksheets1Based ? 1 : 0;
+                    package.Workbook.Worksheets[worksheetIndex].Column(1).Hidden.ShouldBeTrue();
+                }
             }
         }
 
@@ -99,7 +106,8 @@ namespace LargeXlsx.Tests
                     });
                 using (var package = new ExcelPackage(stream))
                 {
-                    var worksheet = package.Workbook.Worksheets[0];
+                    var worksheetIndex = package.Compatibility.IsWorksheets1Based ? 1 : 0;
+                    var worksheet = package.Workbook.Worksheets[worksheetIndex];
                     worksheet.Column(1).Hidden.ShouldBeTrue();
                     worksheet.Column(2).Hidden.ShouldBeTrue();
                     worksheet.Column(3).Hidden.ShouldBeFalse();

--- a/LargeXlsx.Tests/DataValidationTest.cs
+++ b/LargeXlsx.Tests/DataValidationTest.cs
@@ -54,7 +54,8 @@ namespace LargeXlsx.Tests
 
                 using (var package = new ExcelPackage(stream))
                 {
-                    var dataValidation = package.Workbook.Worksheets[0].DataValidations[0] as ExcelDataValidationList;
+                    var worksheetIndex = package.Compatibility.IsWorksheets1Based ? 1 : 0;
+                    var dataValidation = package.Workbook.Worksheets[worksheetIndex].DataValidations[0] as ExcelDataValidationList;
                     dataValidation.ShouldNotBeNull();
                     dataValidation.ValidationType.ShouldBe(ExcelDataValidationType.List);
                     dataValidation.Address.Address.ShouldBe("A1 C1:D1");
@@ -73,7 +74,8 @@ namespace LargeXlsx.Tests
                         .AddDataValidation(XlsxDataValidation.List(new[] {"Lorem", "Ipsum", "Dolor"})).Write();
                 using (var package = new ExcelPackage(stream))
                 {
-                    var dataValidation = package.Workbook.Worksheets[0].DataValidations[0] as ExcelDataValidationList;
+                    var worksheetIndex = package.Compatibility.IsWorksheets1Based ? 1 : 0;
+                    var dataValidation = package.Workbook.Worksheets[worksheetIndex].DataValidations[0] as ExcelDataValidationList;
                     dataValidation.ShouldNotBeNull();
                     dataValidation.ValidationType.ShouldBe(ExcelDataValidationType.List);
                     dataValidation.Address.Address.ShouldBe("A1");
@@ -100,7 +102,8 @@ namespace LargeXlsx.Tests
 
                 using (var package = new ExcelPackage(stream))
                 {
-                    var dataValidation = package.Workbook.Worksheets[0].DataValidations[0] as ExcelDataValidationList;
+                    var worksheetIndex = package.Compatibility.IsWorksheets1Based ? 1 : 0;
+                    var dataValidation = package.Workbook.Worksheets[worksheetIndex].DataValidations[0] as ExcelDataValidationList;
                     dataValidation.ShouldNotBeNull();
                     dataValidation.ValidationType.ShouldBe(ExcelDataValidationType.List);
                     dataValidation.Address.Address.ShouldBe("A1");
@@ -120,8 +123,9 @@ namespace LargeXlsx.Tests
                             formula2: "10"));
                 using (var package = new ExcelPackage(stream))
                 {
+                    var worksheetIndex = package.Compatibility.IsWorksheets1Based ? 1 : 0;
                     var dataValidation =
-                        package.Workbook.Worksheets[0].DataValidations[0] as ExcelDataValidationDecimal;
+                        package.Workbook.Worksheets[worksheetIndex].DataValidations[0] as ExcelDataValidationDecimal;
                     dataValidation.ShouldNotBeNull();
                     dataValidation.Formula.Value.ShouldBe(1.0);
                     dataValidation.Formula2.Value.ShouldBe(10.0);
@@ -145,7 +149,8 @@ namespace LargeXlsx.Tests
 
                 using (var package = new ExcelPackage(stream))
                 {
-                    var dataValidation = (ExcelDataValidationList) package.Workbook.Worksheets[0].DataValidations[0];
+                    var worksheetIndex = package.Compatibility.IsWorksheets1Based ? 1 : 0;
+                    var dataValidation = (ExcelDataValidationList) package.Workbook.Worksheets[worksheetIndex].DataValidations[0];
                     dataValidation.ShowErrorMessage.ShouldBe(true);
                     dataValidation.ErrorTitle.ShouldBe("Error title");
                     dataValidation.Error.ShouldBe("A very informative error message");
@@ -170,7 +175,8 @@ namespace LargeXlsx.Tests
                             errorStyle: errorStyle));
                 using (var package = new ExcelPackage(stream))
                 {
-                    var dataValidation = (ExcelDataValidationList) package.Workbook.Worksheets[0].DataValidations[0];
+                    var worksheetIndex = package.Compatibility.IsWorksheets1Based ? 1 : 0;
+                    var dataValidation = (ExcelDataValidationList) package.Workbook.Worksheets[worksheetIndex].DataValidations[0];
                     dataValidation.ErrorStyle.ShouldBe(expected);
                 }
             }
@@ -193,7 +199,10 @@ namespace LargeXlsx.Tests
                     xlsxWriter.BeginWorksheet("Sheet 1").BeginRow()
                         .AddDataValidation(new XlsxDataValidation(validationType: validationType));
                 using (var package = new ExcelPackage(stream))
-                    package.Workbook.Worksheets[0].DataValidations[0].ValidationType.Type.ShouldBe(expected);
+                {
+                    var worksheetIndex = package.Compatibility.IsWorksheets1Based ? 1 : 0;
+                    package.Workbook.Worksheets[worksheetIndex].DataValidations[0].ValidationType.Type.ShouldBe(expected);
+                }
             }
         }
 
@@ -214,8 +223,11 @@ namespace LargeXlsx.Tests
                         new XlsxDataValidation(validationType: XlsxDataValidation.ValidationType.Decimal,
                             operatorType: operatorType));
                 using (var package = new ExcelPackage(stream))
-                    ((ExcelDataValidationDecimal) package.Workbook.Worksheets[0].DataValidations[0]).Operator
+                {
+                    var worksheetIndex = package.Compatibility.IsWorksheets1Based ? 1 : 0;
+                    ((ExcelDataValidationDecimal) package.Workbook.Worksheets[worksheetIndex].DataValidations[0]).Operator
                         .ShouldBe(expected);
+                }
             }
         }
     }

--- a/LargeXlsx.Tests/FormulaTest.cs
+++ b/LargeXlsx.Tests/FormulaTest.cs
@@ -29,32 +29,43 @@ using NUnit.Framework;
 using OfficeOpenXml;
 using Shouldly;
 
-namespace LargeXlsx.Tests;
 
-[TestFixture]
-public static class FormulaTest
+namespace LargeXlsx.Tests
 {
-    [Test]
-    public static void FormulaWithResult()
-    {
-        using var stream = new MemoryStream();
-        using (var xlsxWriter = new XlsxWriter(stream))
-            xlsxWriter.BeginWorksheet("Sheet 1").BeginRow().WriteFormula("41.5+1", result: 42.5);
-        using var package = new ExcelPackage(stream);
-        // We don't assert package.Workbook.FullCalcOnLoad because EPPlus always sets it to true
-        package.Workbook.Worksheets[0].Cells["A1"].Formula.ShouldBe("41.5+1");
-        package.Workbook.Worksheets[0].Cells["A1"].Value.ShouldBe("42.5");
-    }
 
-    [Test]
-    public static void FormulaWithoutResult()
+    [TestFixture]
+    public static class FormulaTest
     {
-        using var stream = new MemoryStream();
-        using (var xlsxWriter = new XlsxWriter(stream))
-            xlsxWriter.BeginWorksheet("Sheet 1").BeginRow().WriteFormula("41+1");
-        using var package = new ExcelPackage(stream);
-        // We don't assert package.Workbook.FullCalcOnLoad because EPPlus always sets it to true
-        package.Workbook.Worksheets[0].Cells["A1"].Formula.ShouldBe("41+1");
-        package.Workbook.Worksheets[0].Cells["A1"].Value.ShouldBeNull();
+        [Test]
+        public static void FormulaWithResult()
+        {
+            using (var stream = new MemoryStream())
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                    xlsxWriter.BeginWorksheet("Sheet 1").BeginRow().WriteFormula("41.5+1", result: 42.5);
+                using (var package = new ExcelPackage(stream))
+                {
+                    // We don't assert package.Workbook.FullCalcOnLoad because EPPlus always sets it to true
+                    package.Workbook.Worksheets[0].Cells["A1"].Formula.ShouldBe("41.5+1");
+                    package.Workbook.Worksheets[0].Cells["A1"].Value.ShouldBe("42.5");
+                }
+            }
+        }
+
+        [Test]
+        public static void FormulaWithoutResult()
+        {
+            using (var stream = new MemoryStream())
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                    xlsxWriter.BeginWorksheet("Sheet 1").BeginRow().WriteFormula("41+1");
+                using (var package = new ExcelPackage(stream))
+                {
+                    // We don't assert package.Workbook.FullCalcOnLoad because EPPlus always sets it to true
+                    package.Workbook.Worksheets[0].Cells["A1"].Formula.ShouldBe("41+1");
+                    package.Workbook.Worksheets[0].Cells["A1"].Value.ShouldBeNull();
+                }
+            }
+        }
     }
 }

--- a/LargeXlsx.Tests/FormulaTest.cs
+++ b/LargeXlsx.Tests/FormulaTest.cs
@@ -46,8 +46,10 @@ namespace LargeXlsx.Tests
                 using (var package = new ExcelPackage(stream))
                 {
                     // We don't assert package.Workbook.FullCalcOnLoad because EPPlus always sets it to true
-                    package.Workbook.Worksheets[0].Cells["A1"].Formula.ShouldBe("41.5+1");
-                    package.Workbook.Worksheets[0].Cells["A1"].Value.ShouldBe("42.5");
+
+                    var worksheetIndex = package.Compatibility.IsWorksheets1Based ? 1 : 0;
+                    package.Workbook.Worksheets[worksheetIndex].Cells["A1"].Formula.ShouldBe("41.5+1");
+                    package.Workbook.Worksheets[worksheetIndex].Cells["A1"].Value.ShouldBe("42.5");
                 }
             }
         }
@@ -62,8 +64,10 @@ namespace LargeXlsx.Tests
                 using (var package = new ExcelPackage(stream))
                 {
                     // We don't assert package.Workbook.FullCalcOnLoad because EPPlus always sets it to true
-                    package.Workbook.Worksheets[0].Cells["A1"].Formula.ShouldBe("41+1");
-                    package.Workbook.Worksheets[0].Cells["A1"].Value.ShouldBeNull();
+
+                    var worksheetIndex = package.Compatibility.IsWorksheets1Based ? 1 : 0;
+                    package.Workbook.Worksheets[worksheetIndex].Cells["A1"].Formula.ShouldBe("41+1");
+                    package.Workbook.Worksheets[worksheetIndex].Cells["A1"].Value.ShouldBeNull();
                 }
             }
         }

--- a/LargeXlsx.Tests/HeaderFooterTest.cs
+++ b/LargeXlsx.Tests/HeaderFooterTest.cs
@@ -26,7 +26,8 @@ namespace LargeXlsx.Tests
 
                 using (var package = new ExcelPackage(stream))
                 {
-                    var sheet = package.Workbook.Worksheets[0];
+                    var worksheetIndex = package.Compatibility.IsWorksheets1Based ? 1 : 0;
+                    var sheet = package.Workbook.Worksheets[worksheetIndex];
                     sheet.HeaderFooter.AlignWithMargins.ShouldBeTrue();
                     sheet.HeaderFooter.ScaleWithDocument.ShouldBeTrue();
                     sheet.HeaderFooter.differentFirst.ShouldBeFalse();
@@ -58,7 +59,8 @@ namespace LargeXlsx.Tests
 
                 using (var package = new ExcelPackage(stream))
                 {
-                    var sheet = package.Workbook.Worksheets[0];
+                    var worksheetIndex = package.Compatibility.IsWorksheets1Based ? 1 : 0;
+                    var sheet = package.Workbook.Worksheets[worksheetIndex];
                     sheet.HeaderFooter.AlignWithMargins.ShouldBe(alignWithMargins);
                     sheet.HeaderFooter.ScaleWithDocument.ShouldBe(scaleWithDoc);
                 }
@@ -82,7 +84,8 @@ namespace LargeXlsx.Tests
 
                 using (var package = new ExcelPackage(stream))
                 {
-                    var sheet = package.Workbook.Worksheets[0];
+                    var worksheetIndex = package.Compatibility.IsWorksheets1Based ? 1 : 0;
+                    var sheet = package.Workbook.Worksheets[worksheetIndex];
                     sheet.HeaderFooter.AlignWithMargins.ShouldBeTrue();
                     sheet.HeaderFooter.ScaleWithDocument.ShouldBeTrue();
                     sheet.HeaderFooter.differentFirst.ShouldBeTrue();
@@ -120,7 +123,8 @@ namespace LargeXlsx.Tests
 
                 using (var package = new ExcelPackage(stream))
                 {
-                    var sheet = package.Workbook.Worksheets[0];
+                    var worksheetIndex = package.Compatibility.IsWorksheets1Based ? 1 : 0;
+                    var sheet = package.Workbook.Worksheets[worksheetIndex];
                     sheet.HeaderFooter.AlignWithMargins.ShouldBeTrue();
                     sheet.HeaderFooter.ScaleWithDocument.ShouldBeTrue();
                     sheet.HeaderFooter.differentFirst.ShouldBeFalse();

--- a/LargeXlsx.Tests/HeaderFooterTest.cs
+++ b/LargeXlsx.Tests/HeaderFooterTest.cs
@@ -3,123 +3,142 @@ using OfficeOpenXml;
 using System.IO;
 using Shouldly;
 
-namespace LargeXlsx.Tests;
 
-[TestFixture]
-public static class HeaderFooterTest
+namespace LargeXlsx.Tests
 {
-    [Test]
-    public static void Simple()
+
+    [TestFixture]
+    public static class HeaderFooterTest
     {
-        using var stream = new MemoryStream();
-        using (var xlsxWriter = new XlsxWriter(stream))
+        [Test]
+        public static void Simple()
         {
-            xlsxWriter
-                .BeginWorksheet("HeaderFooterTest")
-                .SetHeaderFooter(new XlsxHeaderFooter(
-                    oddHeader: new XlsxHeaderFooterBuilder().Left().Text("LeftHeader").ToString(),
-                    oddFooter: new XlsxHeaderFooterBuilder().Center().Text("CenterFooter").ToString()));
+            using (var stream = new MemoryStream())
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                {
+                    xlsxWriter
+                        .BeginWorksheet("HeaderFooterTest")
+                        .SetHeaderFooter(new XlsxHeaderFooter(
+                            oddHeader: new XlsxHeaderFooterBuilder().Left().Text("LeftHeader").ToString(),
+                            oddFooter: new XlsxHeaderFooterBuilder().Center().Text("CenterFooter").ToString()));
+                }
+
+                using (var package = new ExcelPackage(stream))
+                {
+                    var sheet = package.Workbook.Worksheets[0];
+                    sheet.HeaderFooter.AlignWithMargins.ShouldBeTrue();
+                    sheet.HeaderFooter.ScaleWithDocument.ShouldBeTrue();
+                    sheet.HeaderFooter.differentFirst.ShouldBeFalse();
+                    sheet.HeaderFooter.differentOddEven.ShouldBeFalse();
+                    sheet.HeaderFooter.OddHeader.LeftAlignedText.ShouldBe("LeftHeader");
+                    sheet.HeaderFooter.OddHeader.CenteredText.ShouldBeNull();
+                    sheet.HeaderFooter.OddHeader.RightAlignedText.ShouldBeNull();
+                    sheet.HeaderFooter.OddFooter.LeftAlignedText.ShouldBeNull();
+                    sheet.HeaderFooter.OddFooter.CenteredText.ShouldBe("CenterFooter");
+                    sheet.HeaderFooter.OddFooter.RightAlignedText.ShouldBeNull();
+                }
+            }
         }
 
-        using var package = new ExcelPackage(stream);
-        var sheet = package.Workbook.Worksheets[0];
-        sheet.HeaderFooter.AlignWithMargins.ShouldBeTrue();
-        sheet.HeaderFooter.ScaleWithDocument.ShouldBeTrue();
-        sheet.HeaderFooter.differentFirst.ShouldBeFalse();
-        sheet.HeaderFooter.differentOddEven.ShouldBeFalse();
-        sheet.HeaderFooter.OddHeader.LeftAlignedText.ShouldBe("LeftHeader");
-        sheet.HeaderFooter.OddHeader.CenteredText.ShouldBeNull();
-        sheet.HeaderFooter.OddHeader.RightAlignedText.ShouldBeNull();
-        sheet.HeaderFooter.OddFooter.LeftAlignedText.ShouldBeNull();
-        sheet.HeaderFooter.OddFooter.CenteredText.ShouldBe("CenterFooter");
-        sheet.HeaderFooter.OddFooter.RightAlignedText.ShouldBeNull();
-    }
-
-    [Theory]
-    public static void Flags(bool alignWithMargins, bool scaleWithDoc)
-    {
-        using var stream = new MemoryStream();
-        using (var xlsxWriter = new XlsxWriter(stream))
+        [Theory]
+        public static void Flags(bool alignWithMargins, bool scaleWithDoc)
         {
-            xlsxWriter
-                .BeginWorksheet("HeaderFooterTest")
-                .SetHeaderFooter(new XlsxHeaderFooter(
-                    alignWithMargins: alignWithMargins,
-                    scaleWithDoc: scaleWithDoc,
-                    oddFooter: new XlsxHeaderFooterBuilder().Center().Text("Footer").ToString()));
+            using (var stream = new MemoryStream())
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                {
+                    xlsxWriter
+                        .BeginWorksheet("HeaderFooterTest")
+                        .SetHeaderFooter(new XlsxHeaderFooter(
+                            alignWithMargins: alignWithMargins,
+                            scaleWithDoc: scaleWithDoc,
+                            oddFooter: new XlsxHeaderFooterBuilder().Center().Text("Footer").ToString()));
+                }
+
+                using (var package = new ExcelPackage(stream))
+                {
+                    var sheet = package.Workbook.Worksheets[0];
+                    sheet.HeaderFooter.AlignWithMargins.ShouldBe(alignWithMargins);
+                    sheet.HeaderFooter.ScaleWithDocument.ShouldBe(scaleWithDoc);
+                }
+            }
         }
 
-        using var package = new ExcelPackage(stream);
-        var sheet = package.Workbook.Worksheets[0];
-        sheet.HeaderFooter.AlignWithMargins.ShouldBe(alignWithMargins);
-        sheet.HeaderFooter.ScaleWithDocument.ShouldBe(scaleWithDoc);
-    }
-
-    [Test]
-    public static void DifferentFirst()
-    {
-        using var stream = new MemoryStream();
-        using (var xlsxWriter = new XlsxWriter(stream))
+        [Test]
+        public static void DifferentFirst()
         {
-            xlsxWriter
-                .BeginWorksheet("HeaderFooterTest")
-                .SetHeaderFooter(new XlsxHeaderFooter(
-                    oddHeader: new XlsxHeaderFooterBuilder().Left().Text("LeftHeader").ToString(),
-                    oddFooter: new XlsxHeaderFooterBuilder().Center().Text("CenterFooter").ToString(),
-                    firstHeader: new XlsxHeaderFooterBuilder().Right().Text("FirstHeader").ToString()));
+            using (var stream = new MemoryStream())
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                {
+                    xlsxWriter
+                        .BeginWorksheet("HeaderFooterTest")
+                        .SetHeaderFooter(new XlsxHeaderFooter(
+                            oddHeader: new XlsxHeaderFooterBuilder().Left().Text("LeftHeader").ToString(),
+                            oddFooter: new XlsxHeaderFooterBuilder().Center().Text("CenterFooter").ToString(),
+                            firstHeader: new XlsxHeaderFooterBuilder().Right().Text("FirstHeader").ToString()));
+                }
+
+                using (var package = new ExcelPackage(stream))
+                {
+                    var sheet = package.Workbook.Worksheets[0];
+                    sheet.HeaderFooter.AlignWithMargins.ShouldBeTrue();
+                    sheet.HeaderFooter.ScaleWithDocument.ShouldBeTrue();
+                    sheet.HeaderFooter.differentFirst.ShouldBeTrue();
+                    sheet.HeaderFooter.differentOddEven.ShouldBeFalse();
+                    sheet.HeaderFooter.FirstHeader.LeftAlignedText.ShouldBeNull();
+                    sheet.HeaderFooter.FirstHeader.CenteredText.ShouldBeNull();
+                    sheet.HeaderFooter.FirstHeader.RightAlignedText.ShouldBe("FirstHeader");
+                    sheet.HeaderFooter.FirstFooter.LeftAlignedText.ShouldBeNull();
+                    sheet.HeaderFooter.FirstFooter.CenteredText.ShouldBeNull();
+                    sheet.HeaderFooter.FirstFooter.RightAlignedText.ShouldBeNull();
+                    sheet.HeaderFooter.OddHeader.LeftAlignedText.ShouldBe("LeftHeader");
+                    sheet.HeaderFooter.OddHeader.CenteredText.ShouldBeNull();
+                    sheet.HeaderFooter.OddHeader.RightAlignedText.ShouldBeNull();
+                    sheet.HeaderFooter.OddFooter.LeftAlignedText.ShouldBeNull();
+                    sheet.HeaderFooter.OddFooter.CenteredText.ShouldBe("CenterFooter");
+                    sheet.HeaderFooter.OddFooter.RightAlignedText.ShouldBeNull();
+                }
+            }
         }
 
-        using var package = new ExcelPackage(stream);
-        var sheet = package.Workbook.Worksheets[0];
-        sheet.HeaderFooter.AlignWithMargins.ShouldBeTrue();
-        sheet.HeaderFooter.ScaleWithDocument.ShouldBeTrue();
-        sheet.HeaderFooter.differentFirst.ShouldBeTrue();
-        sheet.HeaderFooter.differentOddEven.ShouldBeFalse();
-        sheet.HeaderFooter.FirstHeader.LeftAlignedText.ShouldBeNull();
-        sheet.HeaderFooter.FirstHeader.CenteredText.ShouldBeNull();
-        sheet.HeaderFooter.FirstHeader.RightAlignedText.ShouldBe("FirstHeader");
-        sheet.HeaderFooter.FirstFooter.LeftAlignedText.ShouldBeNull();
-        sheet.HeaderFooter.FirstFooter.CenteredText.ShouldBeNull();
-        sheet.HeaderFooter.FirstFooter.RightAlignedText.ShouldBeNull();
-        sheet.HeaderFooter.OddHeader.LeftAlignedText.ShouldBe("LeftHeader");
-        sheet.HeaderFooter.OddHeader.CenteredText.ShouldBeNull();
-        sheet.HeaderFooter.OddHeader.RightAlignedText.ShouldBeNull();
-        sheet.HeaderFooter.OddFooter.LeftAlignedText.ShouldBeNull();
-        sheet.HeaderFooter.OddFooter.CenteredText.ShouldBe("CenterFooter");
-        sheet.HeaderFooter.OddFooter.RightAlignedText.ShouldBeNull();
-    }
-
-    [Test]
-    public static void DifferentOddEven()
-    {
-        using var stream = new MemoryStream();
-        using (var xlsxWriter = new XlsxWriter(stream))
+        [Test]
+        public static void DifferentOddEven()
         {
-            xlsxWriter
-                .BeginWorksheet("HeaderFooterTest")
-                .SetHeaderFooter(new XlsxHeaderFooter(
-                    oddHeader: new XlsxHeaderFooterBuilder().Left().Text("LeftHeader").ToString(),
-                    oddFooter: new XlsxHeaderFooterBuilder().Center().Text("CenterFooter").ToString(),
-                    evenHeader: new XlsxHeaderFooterBuilder().Right().Text("EvenHeader").ToString()));
-        }
+            using (var stream = new MemoryStream())
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                {
+                    xlsxWriter
+                        .BeginWorksheet("HeaderFooterTest")
+                        .SetHeaderFooter(new XlsxHeaderFooter(
+                            oddHeader: new XlsxHeaderFooterBuilder().Left().Text("LeftHeader").ToString(),
+                            oddFooter: new XlsxHeaderFooterBuilder().Center().Text("CenterFooter").ToString(),
+                            evenHeader: new XlsxHeaderFooterBuilder().Right().Text("EvenHeader").ToString()));
+                }
 
-        using var package = new ExcelPackage(stream);
-        var sheet = package.Workbook.Worksheets[0];
-        sheet.HeaderFooter.AlignWithMargins.ShouldBeTrue();
-        sheet.HeaderFooter.ScaleWithDocument.ShouldBeTrue();
-        sheet.HeaderFooter.differentFirst.ShouldBeFalse();
-        sheet.HeaderFooter.differentOddEven.ShouldBeTrue();
-        sheet.HeaderFooter.OddHeader.LeftAlignedText.ShouldBe("LeftHeader");
-        sheet.HeaderFooter.OddHeader.CenteredText.ShouldBeNull();
-        sheet.HeaderFooter.OddHeader.RightAlignedText.ShouldBeNull();
-        sheet.HeaderFooter.OddFooter.LeftAlignedText.ShouldBeNull();
-        sheet.HeaderFooter.OddFooter.CenteredText.ShouldBe("CenterFooter");
-        sheet.HeaderFooter.OddFooter.RightAlignedText.ShouldBeNull();
-        sheet.HeaderFooter.EvenHeader.LeftAlignedText.ShouldBeNull();
-        sheet.HeaderFooter.EvenHeader.CenteredText.ShouldBeNull();
-        sheet.HeaderFooter.EvenHeader.RightAlignedText.ShouldBe("EvenHeader");
-        sheet.HeaderFooter.EvenFooter.LeftAlignedText.ShouldBeNull();
-        sheet.HeaderFooter.EvenFooter.CenteredText.ShouldBeNull();
-        sheet.HeaderFooter.EvenFooter.RightAlignedText.ShouldBeNull();
+                using (var package = new ExcelPackage(stream))
+                {
+                    var sheet = package.Workbook.Worksheets[0];
+                    sheet.HeaderFooter.AlignWithMargins.ShouldBeTrue();
+                    sheet.HeaderFooter.ScaleWithDocument.ShouldBeTrue();
+                    sheet.HeaderFooter.differentFirst.ShouldBeFalse();
+                    sheet.HeaderFooter.differentOddEven.ShouldBeTrue();
+                    sheet.HeaderFooter.OddHeader.LeftAlignedText.ShouldBe("LeftHeader");
+                    sheet.HeaderFooter.OddHeader.CenteredText.ShouldBeNull();
+                    sheet.HeaderFooter.OddHeader.RightAlignedText.ShouldBeNull();
+                    sheet.HeaderFooter.OddFooter.LeftAlignedText.ShouldBeNull();
+                    sheet.HeaderFooter.OddFooter.CenteredText.ShouldBe("CenterFooter");
+                    sheet.HeaderFooter.OddFooter.RightAlignedText.ShouldBeNull();
+                    sheet.HeaderFooter.EvenHeader.LeftAlignedText.ShouldBeNull();
+                    sheet.HeaderFooter.EvenHeader.CenteredText.ShouldBeNull();
+                    sheet.HeaderFooter.EvenHeader.RightAlignedText.ShouldBe("EvenHeader");
+                    sheet.HeaderFooter.EvenFooter.LeftAlignedText.ShouldBeNull();
+                    sheet.HeaderFooter.EvenFooter.CenteredText.ShouldBeNull();
+                    sheet.HeaderFooter.EvenFooter.RightAlignedText.ShouldBeNull();
+                }
+            }
+        }
     }
 }

--- a/LargeXlsx.Tests/LargeXlsx.Tests.csproj
+++ b/LargeXlsx.Tests/LargeXlsx.Tests.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Examples\Examples.csproj" />
+    <ProjectReference Include="..\LargeXlsx\LargeXlsx.csproj" />
   </ItemGroup>
 
 </Project>

--- a/LargeXlsx.Tests/LargeXlsx.Tests.csproj
+++ b/LargeXlsx.Tests/LargeXlsx.Tests.csproj
@@ -5,6 +5,12 @@
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net8.0'">
+		<!-- Settings for .NET 6 or 8 -->
+		<Nullable>enable</Nullable>
+		<WarningsAsErrors>Nullable</WarningsAsErrors>
+	</PropertyGroup>
+
 	<ItemGroup>
 		<PackageReference Include="DocumentFormat.OpenXml" Version="3.3.0" />
 		<PackageReference Include="EPPlus" Version="[4.5.3.3,5.0.0)" />

--- a/LargeXlsx.Tests/LargeXlsx.Tests.csproj
+++ b/LargeXlsx.Tests/LargeXlsx.Tests.csproj
@@ -3,8 +3,6 @@
 	<PropertyGroup>
 		<TargetFrameworks>net48;net6.0;net8.0</TargetFrameworks>
 		<IsPackable>false</IsPackable>
-		<Nullable>enable</Nullable>
-		<WarningsAsErrors>Nullable</WarningsAsErrors>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/LargeXlsx.Tests/LargeXlsx.Tests.csproj
+++ b/LargeXlsx.Tests/LargeXlsx.Tests.csproj
@@ -1,23 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <IsPackable>false</IsPackable>
-    <Nullable>enable</Nullable>
-    <WarningsAsErrors>Nullable</WarningsAsErrors>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFrameworks>net48;net6.0;net8.0</TargetFrameworks>
+		<IsPackable>false</IsPackable>
+		<Nullable>enable</Nullable>
+		<WarningsAsErrors>Nullable</WarningsAsErrors>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="DocumentFormat.OpenXml" Version="3.3.0" />
-    <PackageReference Include="EPPlus" Version="[4.5.3.3,5.0.0)" />
-    <PackageReference Include="nunit" Version="4.3.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="Shouldly" Version="4.3.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="DocumentFormat.OpenXml" Version="3.3.0" />
+		<PackageReference Include="EPPlus" Version="[4.5.3.3,5.0.0)" />
+		<PackageReference Include="nunit" Version="4.3.2" />
+		<PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+		<PackageReference Include="Shouldly" Version="4.3.0" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\LargeXlsx\LargeXlsx.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\LargeXlsx\LargeXlsx.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/LargeXlsx.Tests/PageBreaksTest.cs
+++ b/LargeXlsx.Tests/PageBreaksTest.cs
@@ -52,7 +52,8 @@ namespace LargeXlsx.Tests
 
                 using (var package = new ExcelPackage(stream))
                 {
-                    var sheet = package.Workbook.Worksheets[0];
+                    var worksheetIndex = package.Compatibility.IsWorksheets1Based ? 1 : 0;
+                    var sheet = package.Workbook.Worksheets[worksheetIndex];
                     sheet.Row(1).PageBreak.ShouldBeTrue();
                     sheet.Row(2).PageBreak.ShouldBeFalse();
                     sheet.Row(3).PageBreak.ShouldBeFalse();
@@ -78,7 +79,8 @@ namespace LargeXlsx.Tests
 
                 using (var package = new ExcelPackage(stream))
                 {
-                    var sheet = package.Workbook.Worksheets[0];
+                    var worksheetIndex = package.Compatibility.IsWorksheets1Based ? 1 : 0;
+                    var sheet = package.Workbook.Worksheets[worksheetIndex];
                     sheet.Row(1).PageBreak.ShouldBeFalse();
                     sheet.Row(2).PageBreak.ShouldBeTrue();
                     sheet.Row(3).PageBreak.ShouldBeFalse();

--- a/LargeXlsx.Tests/PageBreaksTest.cs
+++ b/LargeXlsx.Tests/PageBreaksTest.cs
@@ -30,64 +30,81 @@ using Shouldly;
 using System.IO;
 using System;
 
-namespace LargeXlsx.Tests;
 
-public static class PageBreaksTest
+namespace LargeXlsx.Tests
 {
-    [Test]
-    public static void BeforeInsertionPoint()
+
+    public static class PageBreaksTest
     {
-        using var stream = new MemoryStream();
-        using (var xlsxWriter = new XlsxWriter(stream))
+        [Test]
+        public static void BeforeInsertionPoint()
         {
-            xlsxWriter
-                .BeginWorksheet("Sheet1")
-                .BeginRow().Write("A1").Write("B1").AddColumnPageBreak().Write("C1")
-                .BeginRow().Write("A2").AddRowPageBreak().Write("B2").Write("C2")
-                .BeginRow().Write("A3").Write("B3").Write("C3");
+            using (var stream = new MemoryStream())
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                {
+                    xlsxWriter
+                        .BeginWorksheet("Sheet1")
+                        .BeginRow().Write("A1").Write("B1").AddColumnPageBreak().Write("C1")
+                        .BeginRow().Write("A2").AddRowPageBreak().Write("B2").Write("C2")
+                        .BeginRow().Write("A3").Write("B3").Write("C3");
+                }
+
+                using (var package = new ExcelPackage(stream))
+                {
+                    var sheet = package.Workbook.Worksheets[0];
+                    sheet.Row(1).PageBreak.ShouldBeTrue();
+                    sheet.Row(2).PageBreak.ShouldBeFalse();
+                    sheet.Row(3).PageBreak.ShouldBeFalse();
+                    sheet.Column(1).PageBreak.ShouldBeFalse();
+                    sheet.Column(2).PageBreak.ShouldBeTrue();
+                    sheet.Column(3).PageBreak.ShouldBeFalse();
+                }
+            }
         }
 
-        using var package = new ExcelPackage(stream);
-        var sheet = package.Workbook.Worksheets[0];
-        sheet.Row(1).PageBreak.ShouldBeTrue();
-        sheet.Row(2).PageBreak.ShouldBeFalse();
-        sheet.Row(3).PageBreak.ShouldBeFalse();
-        sheet.Column(1).PageBreak.ShouldBeFalse();
-        sheet.Column(2).PageBreak.ShouldBeTrue();
-        sheet.Column(3).PageBreak.ShouldBeFalse();
-    }
-
-    [Test]
-    public static void Specific()
-    {
-        using var stream = new MemoryStream();
-        using (var xlsxWriter = new XlsxWriter(stream))
+        [Test]
+        public static void Specific()
         {
-            xlsxWriter
-                .BeginWorksheet("Sheet1")
-                .AddRowPageBreakBefore(3)
-                .AddColumnPageBreakBefore(2);
+            using (var stream = new MemoryStream())
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                {
+                    xlsxWriter
+                        .BeginWorksheet("Sheet1")
+                        .AddRowPageBreakBefore(3)
+                        .AddColumnPageBreakBefore(2);
+                }
+
+                using (var package = new ExcelPackage(stream))
+                {
+                    var sheet = package.Workbook.Worksheets[0];
+                    sheet.Row(1).PageBreak.ShouldBeFalse();
+                    sheet.Row(2).PageBreak.ShouldBeTrue();
+                    sheet.Row(3).PageBreak.ShouldBeFalse();
+                    sheet.Column(1).PageBreak.ShouldBeTrue();
+                    sheet.Column(2).PageBreak.ShouldBeFalse();
+                    sheet.Column(3).PageBreak.ShouldBeFalse();
+                }
+            }
         }
 
-        using var package = new ExcelPackage(stream);
-        var sheet = package.Workbook.Worksheets[0];
-        sheet.Row(1).PageBreak.ShouldBeFalse();
-        sheet.Row(2).PageBreak.ShouldBeTrue();
-        sheet.Row(3).PageBreak.ShouldBeFalse();
-        sheet.Column(1).PageBreak.ShouldBeTrue();
-        sheet.Column(2).PageBreak.ShouldBeFalse();
-        sheet.Column(3).PageBreak.ShouldBeFalse();
-    }
-
-    [Test]
-    public static void OutOfRange()
-    {
-        using var stream = new MemoryStream();
-        using var xlsxWriter = new XlsxWriter(stream);
-        xlsxWriter.BeginWorksheet("Sheet1");
-        Should.Throw<ArgumentOutOfRangeException>(() => xlsxWriter.AddColumnPageBreakBefore(1));
-        Should.Throw<ArgumentOutOfRangeException>(() => xlsxWriter.AddColumnPageBreakBefore(Limits.MaxColumnCount + 1));
-        Should.Throw<ArgumentOutOfRangeException>(() => xlsxWriter.AddRowPageBreakBefore(1));
-        Should.Throw<ArgumentOutOfRangeException>(() => xlsxWriter.AddRowPageBreakBefore(Limits.MaxRowCount + 1));
+        [Test]
+        public static void OutOfRange()
+        {
+            using (var stream = new MemoryStream())
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                {
+                    xlsxWriter.BeginWorksheet("Sheet1");
+                    Should.Throw<ArgumentOutOfRangeException>(() => xlsxWriter.AddColumnPageBreakBefore(1));
+                    Should.Throw<ArgumentOutOfRangeException>(() =>
+                        xlsxWriter.AddColumnPageBreakBefore(Limits.MaxColumnCount + 1));
+                    Should.Throw<ArgumentOutOfRangeException>(() => xlsxWriter.AddRowPageBreakBefore(1));
+                    Should.Throw<ArgumentOutOfRangeException>(() =>
+                        xlsxWriter.AddRowPageBreakBefore(Limits.MaxRowCount + 1));
+                }
+            }
+        }
     }
 }

--- a/LargeXlsx.Tests/RowFormattingTest.cs
+++ b/LargeXlsx.Tests/RowFormattingTest.cs
@@ -45,7 +45,10 @@ namespace LargeXlsx.Tests
                 using (var xlsxWriter = new XlsxWriter(stream))
                     xlsxWriter.BeginWorksheet("Sheet 1").BeginRow(height: 36.5).Write("Test");
                 using (var package = new ExcelPackage(stream))
-                    package.Workbook.Worksheets[0].Row(1).Height.ShouldBe(36.5);
+                {
+                    var worksheetIndex = package.Compatibility.IsWorksheets1Based ? 1 : 0;
+                    package.Workbook.Worksheets[worksheetIndex].Row(1).Height.ShouldBe(36.5);
+                }
             }
         }
 
@@ -57,7 +60,10 @@ namespace LargeXlsx.Tests
                 using (var xlsxWriter = new XlsxWriter(stream))
                     xlsxWriter.BeginWorksheet("Sheet 1").BeginRow(hidden: true).Write("Test");
                 using (var package = new ExcelPackage(stream))
-                    package.Workbook.Worksheets[0].Row(1).Hidden.ShouldBeTrue();
+                {
+                    var worksheetIndex = package.Compatibility.IsWorksheets1Based ? 1 : 0;
+                    package.Workbook.Worksheets[worksheetIndex].Row(1).Hidden.ShouldBeTrue();
+                }
             }
         }
 
@@ -76,7 +82,8 @@ namespace LargeXlsx.Tests
                     xlsxWriter.BeginWorksheet("Sheet 1").BeginRow(style: blueStyle).Write("Test");
                 using (var package = new ExcelPackage(stream))
                 {
-                    var row = package.Workbook.Worksheets[0].Row(1);
+                    var worksheetIndex = package.Compatibility.IsWorksheets1Based ? 1 : 0;
+                    var row = package.Workbook.Worksheets[worksheetIndex].Row(1);
                     row.Style.Fill.PatternType.ShouldBe(ExcelFillStyle.Solid);
                     row.Style.Fill.BackgroundColor.Rgb.ShouldBe("FF004586");
                     row.Style.Font.Color.Rgb.ShouldBe("FFFFFFFF");

--- a/LargeXlsx.Tests/RowFormattingTest.cs
+++ b/LargeXlsx.Tests/RowFormattingTest.cs
@@ -31,47 +31,57 @@ using OfficeOpenXml;
 using OfficeOpenXml.Style;
 using Shouldly;
 
-namespace LargeXlsx.Tests;
-
-[TestFixture]
-public static class RowFormattingTest
+namespace LargeXlsx.Tests
 {
-    [Test]
-    public static void Height()
-    {
-        using var stream = new MemoryStream();
-        using (var xlsxWriter = new XlsxWriter(stream))
-            xlsxWriter.BeginWorksheet("Sheet 1").BeginRow(height: 36.5).Write("Test");
-        using (var package = new ExcelPackage(stream))
-            package.Workbook.Worksheets[0].Row(1).Height.ShouldBe(36.5);
-    }
 
-    [Test]
-    public static void Hidden()
+    [TestFixture]
+    public static class RowFormattingTest
     {
-        using var stream = new MemoryStream();
-        using (var xlsxWriter = new XlsxWriter(stream))
-            xlsxWriter.BeginWorksheet("Sheet 1").BeginRow(hidden: true).Write("Test");
-        using (var package = new ExcelPackage(stream))
-            package.Workbook.Worksheets[0].Row(1).Hidden.ShouldBeTrue();
-    }
+        [Test]
+        public static void Height()
+        {
+            using (var stream = new MemoryStream())
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                    xlsxWriter.BeginWorksheet("Sheet 1").BeginRow(height: 36.5).Write("Test");
+                using (var package = new ExcelPackage(stream))
+                    package.Workbook.Worksheets[0].Row(1).Height.ShouldBe(36.5);
+            }
+        }
 
-    [Test]
-    public static void Style()
-    {
-        var blueStyle = new XlsxStyle(
-            XlsxFont.Default.With(Color.White),
-            new XlsxFill(Color.FromArgb(0, 0x45, 0x86)),
-            XlsxBorder.None,
-            XlsxNumberFormat.General,
-            XlsxAlignment.Default);
-        using var stream = new MemoryStream();
-        using (var xlsxWriter = new XlsxWriter(stream))
-            xlsxWriter.BeginWorksheet("Sheet 1").BeginRow(style: blueStyle).Write("Test");
-        using var package = new ExcelPackage(stream);
-        var row = package.Workbook.Worksheets[0].Row(1);
-        row.Style.Fill.PatternType.ShouldBe(ExcelFillStyle.Solid);
-        row.Style.Fill.BackgroundColor.Rgb.ShouldBe("FF004586");
-        row.Style.Font.Color.Rgb.ShouldBe("FFFFFFFF");
+        [Test]
+        public static void Hidden()
+        {
+            using (var stream = new MemoryStream())
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                    xlsxWriter.BeginWorksheet("Sheet 1").BeginRow(hidden: true).Write("Test");
+                using (var package = new ExcelPackage(stream))
+                    package.Workbook.Worksheets[0].Row(1).Hidden.ShouldBeTrue();
+            }
+        }
+
+        [Test]
+        public static void Style()
+        {
+            var blueStyle = new XlsxStyle(
+                XlsxFont.Default.With(Color.White),
+                new XlsxFill(Color.FromArgb(0, 0x45, 0x86)),
+                XlsxBorder.None,
+                XlsxNumberFormat.General,
+                XlsxAlignment.Default);
+            using (var stream = new MemoryStream())
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                    xlsxWriter.BeginWorksheet("Sheet 1").BeginRow(style: blueStyle).Write("Test");
+                using (var package = new ExcelPackage(stream))
+                {
+                    var row = package.Workbook.Worksheets[0].Row(1);
+                    row.Style.Fill.PatternType.ShouldBe(ExcelFillStyle.Solid);
+                    row.Style.Fill.BackgroundColor.Rgb.ShouldBe("FF004586");
+                    row.Style.Font.Color.Rgb.ShouldBe("FFFFFFFF");
+                }
+            }
+        }
     }
 }

--- a/LargeXlsx.Tests/UtilTest.cs
+++ b/LargeXlsx.Tests/UtilTest.cs
@@ -30,107 +30,111 @@ using System.Xml;
 using NUnit.Framework;
 using Shouldly;
 
-namespace LargeXlsx.Tests;
-
-[TestFixture]
-public static class UtilTest
+namespace LargeXlsx.Tests
 {
-    [Test]
-    public static void AppendEscapedXmlText_AllValid() =>
-        new StringWriter()
-            .AppendEscapedXmlText("Lorem 'ipsum' & \"dolor\" \U0001d11e <sit> amet", skipInvalidCharacters: false)
-            .ToString().ShouldBe("Lorem 'ipsum' &amp; \"dolor\" \U0001d11e &lt;sit&gt; amet");
-
-    [TestCase(new[] { 'a', '\0', 'b' })]
-    [TestCase(new[] { 'a', '\ud800', 'b' })]
-    [TestCase(new[] { 'a', '\udc00', 'b' })]
-    public static void AppendEscapedXmlText_InvalidChars_Throw(char[] value) => 
-        Should.Throw<XmlException>(() => new StringWriter().AppendEscapedXmlText(new string(value), skipInvalidCharacters: false));
-
-    [TestCase(new[] { 'a', '\0', 'b' })]
-    [TestCase(new[] { 'a', '\ud800', 'b' })]
-    [TestCase(new[] { 'a', '\udc00', 'b' })]
-    public static void AppendEscapedXmlText_InvalidChars_Skip(char[] value) =>
-        new StringWriter()
-            .AppendEscapedXmlText(new string(value), skipInvalidCharacters: true)
-            .ToString().ShouldBe("ab");
-
-    [Test]
-    public static void AppendEscapedXmlAttribute_AllValid() =>
-        new StringWriter()
-            .AppendEscapedXmlAttribute("Lorem 'ipsum' & \"dolor\" \U0001d11e <sit> amet", skipInvalidCharacters: false)
-            .ToString().ShouldBe("Lorem &apos;ipsum&apos; &amp; &quot;dolor&quot; \U0001d11e &lt;sit&gt; amet");
-
-    [TestCase(new[] { 'a', '\0', 'b' })]
-    [TestCase(new[] { 'a', '\ud800', 'b' })]
-    [TestCase(new[] { 'a', '\udc00', 'b' })]
-    public static void AppendEscapedXmlAttribute_InvalidChars_Throw(char[] value) => 
-        Should.Throw<XmlException>(() => new StringWriter().AppendEscapedXmlAttribute(new string(value), skipInvalidCharacters: false));
-
-    [TestCase(new[] { 'a', '\0', 'b' })]
-    [TestCase(new[] { 'a', '\ud800', 'b' })]
-    [TestCase(new[] { 'a', '\udc00', 'b' })]
-    public static void AppendEscapedXmlAttribute_InvalidChars_Skip(char[] value) =>
-        new StringWriter()
-            .AppendEscapedXmlAttribute(new string(value), skipInvalidCharacters: true)
-            .ToString().ShouldBe("ab");
-
-    [TestCase(1, "A")]
-    [TestCase(2, "B")]
-    [TestCase(26, "Z")]
-    [TestCase(27, "AA")]
-    [TestCase(28, "AB")]
-    [TestCase(52, "AZ")]
-    [TestCase(53, "BA")]
-    [TestCase(702, "ZZ")]
-    [TestCase(703, "AAA")]
-    [TestCase(704, "AAB")]
-    [TestCase(729, "ABA")]
-    [TestCase(1378, "AZZ")]
-    [TestCase(1379, "BAA")]
-    [TestCase(16384, "XFD")]
-    public static void GetColumnName(int index, string expectedName)
+    [TestFixture]
+    public static class UtilTest
     {
-        var name = Util.GetColumnName(index);
-        name.ShouldBe(expectedName);
+        [Test]
+        public static void AppendEscapedXmlText_AllValid() =>
+            new StringWriter()
+                .AppendEscapedXmlText("Lorem 'ipsum' & \"dolor\" \U0001d11e <sit> amet", skipInvalidCharacters: false)
+                .ToString().ShouldBe("Lorem 'ipsum' &amp; \"dolor\" \U0001d11e &lt;sit&gt; amet");
+
+        [TestCase(new[] {'a', '\0', 'b'})]
+        [TestCase(new[] {'a', '\ud800', 'b'})]
+        [TestCase(new[] {'a', '\udc00', 'b'})]
+        public static void AppendEscapedXmlText_InvalidChars_Throw(char[] value) =>
+            Should.Throw<XmlException>(() =>
+                new StringWriter().AppendEscapedXmlText(new string(value), skipInvalidCharacters: false));
+
+        [TestCase(new[] {'a', '\0', 'b'})]
+        [TestCase(new[] {'a', '\ud800', 'b'})]
+        [TestCase(new[] {'a', '\udc00', 'b'})]
+        public static void AppendEscapedXmlText_InvalidChars_Skip(char[] value) =>
+            new StringWriter()
+                .AppendEscapedXmlText(new string(value), skipInvalidCharacters: true)
+                .ToString().ShouldBe("ab");
+
+        [Test]
+        public static void AppendEscapedXmlAttribute_AllValid() =>
+            new StringWriter()
+                .AppendEscapedXmlAttribute("Lorem 'ipsum' & \"dolor\" \U0001d11e <sit> amet",
+                    skipInvalidCharacters: false)
+                .ToString().ShouldBe("Lorem &apos;ipsum&apos; &amp; &quot;dolor&quot; \U0001d11e &lt;sit&gt; amet");
+
+        [TestCase(new[] {'a', '\0', 'b'})]
+        [TestCase(new[] {'a', '\ud800', 'b'})]
+        [TestCase(new[] {'a', '\udc00', 'b'})]
+        public static void AppendEscapedXmlAttribute_InvalidChars_Throw(char[] value) =>
+            Should.Throw<XmlException>(() =>
+                new StringWriter().AppendEscapedXmlAttribute(new string(value), skipInvalidCharacters: false));
+
+        [TestCase(new[] {'a', '\0', 'b'})]
+        [TestCase(new[] {'a', '\ud800', 'b'})]
+        [TestCase(new[] {'a', '\udc00', 'b'})]
+        public static void AppendEscapedXmlAttribute_InvalidChars_Skip(char[] value) =>
+            new StringWriter()
+                .AppendEscapedXmlAttribute(new string(value), skipInvalidCharacters: true)
+                .ToString().ShouldBe("ab");
+
+        [TestCase(1, "A")]
+        [TestCase(2, "B")]
+        [TestCase(26, "Z")]
+        [TestCase(27, "AA")]
+        [TestCase(28, "AB")]
+        [TestCase(52, "AZ")]
+        [TestCase(53, "BA")]
+        [TestCase(702, "ZZ")]
+        [TestCase(703, "AAA")]
+        [TestCase(704, "AAB")]
+        [TestCase(729, "ABA")]
+        [TestCase(1378, "AZZ")]
+        [TestCase(1379, "BAA")]
+        [TestCase(16384, "XFD")]
+        public static void GetColumnName(int index, string expectedName)
+        {
+            var name = Util.GetColumnName(index);
+            name.ShouldBe(expectedName);
+        }
+
+        [TestCase(-1)]
+        [TestCase(0)]
+        [TestCase(16385)]
+        public static void GetColumnNameOutOfRange(int index) =>
+            Should.Throw<InvalidOperationException>(() => Util.GetColumnName(index));
+
+        [TestCase("2020-05-06T18:27:00", 43957.76875)]
+        [TestCase("1900-01-01", 1)]
+        [TestCase("1900-02-28", 59)]
+        [TestCase("1900-03-01", 61)]
+        public static void DateToDouble(string dateString, double expected)
+        {
+            var date = DateTime.Parse(dateString);
+            var serialDate = Util.DateToDouble(date);
+            serialDate.ShouldBe(expected, tolerance: 0.000001);
+        }
+
+        [Test]
+        public static void ComputePasswordHash() =>
+            Convert.ToBase64String(Util.ComputePasswordHash(
+                    password: "Lorem ipsum",
+                    saltValue: Convert.FromBase64String("5kelhTC7DUqQ5qi78ihM8A=="),
+                    spinCount: 100000))
+                .ShouldBe("/dQmPXViT1u/fiTHmjLlP2HqOjYeRKI8W367Qn/Eikv63K8nnZMiyk2Wl9ShdHaBL7y1AeeJq5gxm4bW0ArxYg==");
+
+        [TestCase(" leading space", " xml:space=\"preserve\"")]
+        [TestCase("\tleading tab", " xml:space=\"preserve\"")]
+        [TestCase("\rleading CR", " xml:space=\"preserve\"")]
+        [TestCase("\nleading LF", " xml:space=\"preserve\"")]
+        [TestCase("trailing space ", " xml:space=\"preserve\"")]
+        [TestCase("trailing tab\t", " xml:space=\"preserve\"")]
+        [TestCase("trailing CR\n", " xml:space=\"preserve\"")]
+        [TestCase("trailing LF\n", " xml:space=\"preserve\"")]
+        [TestCase("middle   spaces", "")]
+        public static void AddSpacePreserveIfNeeded_LeadingOrTrailingWhitespace(string value, string expectation) =>
+            new StringWriter()
+                .AddSpacePreserveIfNeeded(value)
+                .ToString().ShouldBe(expectation);
     }
-
-    [TestCase(-1)]
-    [TestCase(0)]
-    [TestCase(16385)]
-    public static void GetColumnNameOutOfRange(int index) => 
-        Should.Throw<InvalidOperationException>(() => Util.GetColumnName(index));
-
-    [TestCase("2020-05-06T18:27:00", 43957.76875)]
-    [TestCase("1900-01-01", 1)]
-    [TestCase("1900-02-28", 59)]
-    [TestCase("1900-03-01", 61)]
-    public static void DateToDouble(string dateString, double expected)
-    {
-        var date = DateTime.Parse(dateString);
-        var serialDate = Util.DateToDouble(date);
-        serialDate.ShouldBe(expected, tolerance: 0.000001);
-    }
-
-    [Test]
-    public static void ComputePasswordHash() =>
-        Convert.ToBase64String(Util.ComputePasswordHash(
-                password: "Lorem ipsum",
-                saltValue: Convert.FromBase64String("5kelhTC7DUqQ5qi78ihM8A=="),
-                spinCount: 100000))
-            .ShouldBe("/dQmPXViT1u/fiTHmjLlP2HqOjYeRKI8W367Qn/Eikv63K8nnZMiyk2Wl9ShdHaBL7y1AeeJq5gxm4bW0ArxYg==");
-
-    [TestCase(" leading space", " xml:space=\"preserve\"")]
-    [TestCase("\tleading tab", " xml:space=\"preserve\"")]
-    [TestCase("\rleading CR", " xml:space=\"preserve\"")]
-    [TestCase("\nleading LF", " xml:space=\"preserve\"")]
-    [TestCase("trailing space ", " xml:space=\"preserve\"")]
-    [TestCase("trailing tab\t", " xml:space=\"preserve\"")]
-    [TestCase("trailing CR\n", " xml:space=\"preserve\"")]
-    [TestCase("trailing LF\n", " xml:space=\"preserve\"")]
-    [TestCase("middle   spaces", "")]
-    public static void AddSpacePreserveIfNeeded_LeadingOrTrailingWhitespace(string value, string expectation) =>
-        new StringWriter()
-            .AddSpacePreserveIfNeeded(value)
-            .ToString().ShouldBe(expectation);
 }

--- a/LargeXlsx.Tests/XlsxHeaderFooterBuilderTest.cs
+++ b/LargeXlsx.Tests/XlsxHeaderFooterBuilderTest.cs
@@ -27,46 +27,49 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 using NUnit.Framework;
 using Shouldly;
 
-namespace LargeXlsx.Tests;
-
-[TestFixture]
-public static class XlsxHeaderFooterBuilderTest
+namespace LargeXlsx.Tests
 {
-    [Test]
-    public static void Simple() =>
-        new XlsxHeaderFooterBuilder()
-            .Left().Bold().Italic().Underline().Text("Left&Formatted")
-            .Center().DoubleUnderline().Subscript().PageNumber().NumberOfPages().CurrentDate().CurrentTime().FilePath().FileName()
-            .Right().Superscript().StrikeThrough().SheetName()
-            .ToString()
-            .ShouldBe("&L&B&I&ULeft&&Formatted"
-                         + "&C&E&Y&P&N&D&T&Z&F"
-                         + "&R&X&S&A");
 
-    [TestCase(0, "&P")]
-    [TestCase(1, "&P+1")]
-    [TestCase(-1, "&P-1")]
-    [TestCase(42, "&P+42")]
-    [TestCase(-69, "&P-69")]
-    public static void PageNumber(int offset, string expected) => 
-        new XlsxHeaderFooterBuilder().PageNumber(offset).ToString().ShouldBe(expected);
+    [TestFixture]
+    public static class XlsxHeaderFooterBuilderTest
+    {
+        [Test]
+        public static void Simple() =>
+            new XlsxHeaderFooterBuilder()
+                .Left().Bold().Italic().Underline().Text("Left&Formatted")
+                .Center().DoubleUnderline().Subscript().PageNumber().NumberOfPages().CurrentDate().CurrentTime()
+                .FilePath().FileName()
+                .Right().Superscript().StrikeThrough().SheetName()
+                .ToString()
+                .ShouldBe("&L&B&I&ULeft&&Formatted"
+                          + "&C&E&Y&P&N&D&T&Z&F"
+                          + "&R&X&S&A");
 
-    [TestCase(1, "&1")]
-    [TestCase(42, "&42")]
-    public static void FontSize(int points, string expected) => 
-        new XlsxHeaderFooterBuilder().FontSize(points).ToString().ShouldBe(expected);
+        [TestCase(0, "&P")]
+        [TestCase(1, "&P+1")]
+        [TestCase(-1, "&P-1")]
+        [TestCase(42, "&P+42")]
+        [TestCase(-69, "&P-69")]
+        public static void PageNumber(int offset, string expected) =>
+            new XlsxHeaderFooterBuilder().PageNumber(offset).ToString().ShouldBe(expected);
 
-    [TestCase("Times New Roman", false, false, "&\"Times New Roman,Regular\"")]
-    [TestCase("Times New Roman", true, false, "&\"Times New Roman,Bold\"")]
-    [TestCase("Times New Roman", false, true, "&\"Times New Roman,Italic\"")]
-    [TestCase("Times New Roman", true, true, "&\"Times New Roman,Bold Italic\"")]
-    public static void Font(string name, bool bold, bool italic, string expected) => 
-        new XlsxHeaderFooterBuilder().Font(name, bold, italic).ToString().ShouldBe(expected);
+        [TestCase(1, "&1")]
+        [TestCase(42, "&42")]
+        public static void FontSize(int points, string expected) =>
+            new XlsxHeaderFooterBuilder().FontSize(points).ToString().ShouldBe(expected);
 
-    [TestCase(false, false, "&\"-,Regular\"")]
-    [TestCase(true, false, "&\"-,Bold\"")]
-    [TestCase(false, true, "&\"-,Italic\"")]
-    [TestCase(true, true, "&\"-,Bold Italic\"")]
-    public static void FontWithoutName(bool bold, bool italic, string expected) => 
-        new XlsxHeaderFooterBuilder().Font(bold, italic).ToString().ShouldBe(expected);
+        [TestCase("Times New Roman", false, false, "&\"Times New Roman,Regular\"")]
+        [TestCase("Times New Roman", true, false, "&\"Times New Roman,Bold\"")]
+        [TestCase("Times New Roman", false, true, "&\"Times New Roman,Italic\"")]
+        [TestCase("Times New Roman", true, true, "&\"Times New Roman,Bold Italic\"")]
+        public static void Font(string name, bool bold, bool italic, string expected) =>
+            new XlsxHeaderFooterBuilder().Font(name, bold, italic).ToString().ShouldBe(expected);
+
+        [TestCase(false, false, "&\"-,Regular\"")]
+        [TestCase(true, false, "&\"-,Bold\"")]
+        [TestCase(false, true, "&\"-,Italic\"")]
+        [TestCase(true, true, "&\"-,Bold Italic\"")]
+        public static void FontWithoutName(bool bold, bool italic, string expected) =>
+            new XlsxHeaderFooterBuilder().Font(bold, italic).ToString().ShouldBe(expected);
+    }
 }

--- a/LargeXlsx.Tests/XlsxWriterTest.cs
+++ b/LargeXlsx.Tests/XlsxWriterTest.cs
@@ -35,518 +35,606 @@ using OfficeOpenXml.DataValidation;
 using OfficeOpenXml.Style;
 using Shouldly;
 
-namespace LargeXlsx.Tests;
-
-[TestFixture]
-public static class XlsxWriterTest
+namespace LargeXlsx.Tests
 {
-    [Test]
-    public static void DisposeWriterTwice()
+
+    [TestFixture]
+    public static class XlsxWriterTest
     {
-        using var stream = new MemoryStream();
-        var xlsxWriter = new XlsxWriter(stream);
-        xlsxWriter.BeginWorksheet("Sheet 1").BeginRow().Write("Hello World!");
-        xlsxWriter.Dispose();
-        Should.NotThrow(() => xlsxWriter.Dispose());
-    }
-
-    [Test]
-    public static void InsertionPoint()
-    {
-        using var stream = new MemoryStream();
-        using var xlsxWriter = new XlsxWriter(stream);
-        xlsxWriter.BeginWorksheet("Sheet1")
-            .BeginRow().Write("A1").Write("B1")
-            .BeginRow().Write("A2");
-
-        xlsxWriter.CurrentRowNumber.ShouldBe(2);
-        xlsxWriter.CurrentColumnNumber.ShouldBe(2);
-    }
-
-    [Test]
-    public static void InsertionPointAfterSkipColumn()
-    {
-        using var stream = new MemoryStream();
-        using var xlsxWriter = new XlsxWriter(stream);
-        xlsxWriter.BeginWorksheet("Sheet1")
-            .BeginRow().Write("A1").Write("B1")
-            .BeginRow().Write("A2").SkipColumns(2);
-
-        xlsxWriter.CurrentRowNumber.ShouldBe(2);
-        xlsxWriter.CurrentColumnNumber.ShouldBe(4);
-    }
-
-    [Test]
-    public static void InsertionPointAfterSkipRows()
-    {
-        using var stream = new MemoryStream();
-        using var xlsxWriter = new XlsxWriter(stream);
-        xlsxWriter.BeginWorksheet("Sheet1")
-            .BeginRow().Write("A1").Write("B1")
-            .SkipRows(2);
-
-        xlsxWriter.CurrentRowNumber.ShouldBe(3);
-        xlsxWriter.CurrentColumnNumber.ShouldBe(0);
-    }
-
-    [Test]
-    public static void InsertionPointAfterMergedCells()
-    {
-        using var stream = new MemoryStream();
-        using var xlsxWriter = new XlsxWriter(stream);
-        xlsxWriter.BeginWorksheet("Sheet1")
-            .BeginRow().Write("A1").Write("B1", columnSpan: 3);
-
-        xlsxWriter.CurrentRowNumber.ShouldBe(1);
-        xlsxWriter.CurrentColumnNumber.ShouldBe(5);
-    }
-
-    [Test]
-    public static void Write()
-    {
-        using var stream = new MemoryStream();
-        using (var xlsxWriter = new XlsxWriter(stream))
+        [Test]
+        public static void DisposeWriterTwice()
         {
-            xlsxWriter
-                .BeginWorksheet("Sheet1")
-                .BeginRow()
-                .Write("A string")
-                .Write(123)
-                .Write(456.0)
-                .Write(789m)
-                .Write(new DateTime(2020, 5, 6, 18, 27, 0), XlsxStyle.Default.With(XlsxNumberFormat.ShortDateTime))
-                .Write(true)
-                .Write();
+            using (var stream = new MemoryStream())
+            {
+                var xlsxWriter = new XlsxWriter(stream);
+                xlsxWriter.BeginWorksheet("Sheet 1").BeginRow().Write("Hello World!");
+                xlsxWriter.Dispose();
+                Should.NotThrow(() => xlsxWriter.Dispose());
+            }
         }
 
-        using var package = new ExcelPackage(stream);
-        package.Workbook.Worksheets.Count.ShouldBe(1);
-        var sheet = package.Workbook.Worksheets[0];
-        sheet.Cells["A1"].Value.ShouldBe("A string");
-        sheet.Cells["B1"].Value.ShouldBe(123.0);
-        sheet.Cells["C1"].Value.ShouldBe(456.0);
-        sheet.Cells["D1"].Value.ShouldBe(789.0);
-        sheet.Cells["E1"].Value.ShouldBe(new DateTime(2020, 5, 6, 18, 27, 0));
-        sheet.Cells["F1"].Value.ShouldBe(true);
-        sheet.Cells["G1"].Value.ShouldBeNull();
-    }
-
-    [Test]
-    public static void Simple()
-    {
-        using var stream = new MemoryStream();
-        using (var xlsxWriter = new XlsxWriter(stream))
+        [Test]
+        public static void InsertionPoint()
         {
-            var whiteFont = new XlsxFont("Segoe UI", 9, System.Drawing.Color.White, bold: true);
-            var blueFill = new XlsxFill(System.Drawing.Color.FromArgb(0, 0x45, 0x86));
-            var yellowFill = new XlsxFill(System.Drawing.Color.FromArgb(0xff, 0xff, 0x88));
-            var headerStyle = new XlsxStyle(whiteFont, blueFill, XlsxBorder.None, XlsxNumberFormat.General, XlsxAlignment.Default);
-            var highlightStyle = XlsxStyle.Default.With(yellowFill);
-            var dateStyle = XlsxStyle.Default.With(XlsxNumberFormat.ShortDateTime);
+            using (var stream = new MemoryStream())
+            using (var xlsxWriter = new XlsxWriter(stream))
+            {
+                xlsxWriter.BeginWorksheet("Sheet1")
+                    .BeginRow().Write("A1").Write("B1")
+                    .BeginRow().Write("A2");
 
-            xlsxWriter
-                .BeginWorksheet("Sheet&'<1>\"")
-                .SetDefaultStyle(headerStyle)
-                .BeginRow().Write("Col<1>").Write("Col2").Write("Col&3")
-                .BeginRow().Write().Write("Sub2").Write("Sub3")
-                .SetDefaultStyle(XlsxStyle.Default)
-                .BeginRow().Write("Row3").Write(42).Write(-1, highlightStyle)
-                .BeginRow().Write("Row4").SkipColumns(1).Write(new DateTime(2020, 5, 6, 18, 27, 0), dateStyle)
-                .SkipRows(2)
-                .BeginRow().Write("Row7", columnSpan: 2).Write(3.14159265359)
-                .BeginRow().Write("Row8").Write(false).Write(true);
+                xlsxWriter.CurrentRowNumber.ShouldBe(2);
+                xlsxWriter.CurrentColumnNumber.ShouldBe(2);
+            }
         }
 
-        using var package = new ExcelPackage(stream);
-        package.Workbook.Worksheets.Count.ShouldBe(1);
-        var sheet = package.Workbook.Worksheets[0];
-        sheet.Name.ShouldBe("Sheet&'<1>\"");
-
-        sheet.Cells["A1"].Value.ShouldBe("Col<1>");
-        sheet.Cells["B1"].Value.ShouldBe("Col2");
-        sheet.Cells["C1"].Value.ShouldBe("Col&3");
-        sheet.Cells["A2"].Value.ShouldBeNull();
-        sheet.Cells["B2"].Value.ShouldBe("Sub2");
-        sheet.Cells["C2"].Value.ShouldBe("Sub3");
-        sheet.Cells["A3"].Value.ShouldBe("Row3");
-        sheet.Cells["B3"].Value.ShouldBe(42);
-        sheet.Cells["C3"].Value.ShouldBe(-1);
-        sheet.Cells["A4"].Value.ShouldBe("Row4");
-        sheet.Cells["B4"].Value.ShouldBeNull();
-        sheet.Cells["C4"].Value.ShouldBe(new DateTime(2020, 5, 6, 18, 27, 0));
-        sheet.Cells["C4"].Style.Numberformat.NumFmtID.ShouldBe(22);
-        sheet.Cells["A5"].Value.ShouldBeNull();
-        sheet.Cells["A6"].Value.ShouldBeNull();
-        sheet.Cells["A7"].Value.ShouldBe("Row7");
-        sheet.Cells["B7"].Value.ShouldBeNull();
-        sheet.Cells["C7"].Value.ShouldBe(3.14159265359);
-        sheet.Cells["A8"].Value.ShouldBe("Row8");
-        sheet.Cells["B8"].Value.ShouldBe(false);
-        sheet.Cells["C8"].Value.ShouldBe(true);
-
-        sheet.Cells["A7:B7"].Merge.ShouldBeTrue();
-
-        foreach (var cell in new[] { "A1", "B1", "C1", "A2", "B2", "C2" })
+        [Test]
+        public static void InsertionPointAfterSkipColumn()
         {
-            sheet.Cells[cell].Style.Fill.PatternType.ShouldBe(ExcelFillStyle.Solid);
-            sheet.Cells[cell].Style.Fill.BackgroundColor.Rgb.ShouldBe("FF004586");
-            sheet.Cells[cell].Style.Font.Bold.ShouldBeTrue();
-            sheet.Cells[cell].Style.Font.Color.Rgb.ShouldBe("FFFFFFFF");
-            sheet.Cells[cell].Style.Font.Name.ShouldBe("Segoe UI");
-            sheet.Cells[cell].Style.Font.Size.ShouldBe(9);
+            using (var stream = new MemoryStream())
+            using (var xlsxWriter = new XlsxWriter(stream))
+            {
+                xlsxWriter.BeginWorksheet("Sheet1")
+                    .BeginRow().Write("A1").Write("B1")
+                    .BeginRow().Write("A2").SkipColumns(2);
+
+                xlsxWriter.CurrentRowNumber.ShouldBe(2);
+                xlsxWriter.CurrentColumnNumber.ShouldBe(4);
+            }
         }
 
-        sheet.Cells["C3"].Style.Fill.PatternType.ShouldBe(ExcelFillStyle.Solid);
-        sheet.Cells["C3"].Style.Fill.BackgroundColor.Rgb.ShouldBe("FFFFFF88");
-        sheet.Cells["C3"].Style.Font.Bold.ShouldBeFalse();
-        sheet.Cells["C3"].Style.Font.Color.Rgb.ShouldBe("FF000000");
-        sheet.Cells["C3"].Style.Font.Name.ShouldBe("Calibri");
-        sheet.Cells["C3"].Style.Font.Size.ShouldBe(11);
-
-        foreach (var cell in new[] { "A3", "B3", "A4", "B4", "C4", "A5", "B5", "C5", "A6", "B6", "C6", "A7", "B7", "C7" })
+        [Test]
+        public static void InsertionPointAfterSkipRows()
         {
-            sheet.Cells[cell].Style.Fill.PatternType.ShouldBe(ExcelFillStyle.None);
-            sheet.Cells[cell].Style.Font.Bold.ShouldBeFalse();
-            sheet.Cells[cell].Style.Font.Color.Rgb.ShouldBe("FF000000");
-            sheet.Cells[cell].Style.Font.Name.ShouldBe("Calibri");
-            sheet.Cells[cell].Style.Font.Size.ShouldBe(11);
-        }
-    }
+            using (var stream = new MemoryStream())
+            using (var xlsxWriter = new XlsxWriter(stream))
+            {
+                xlsxWriter.BeginWorksheet("Sheet1")
+                    .BeginRow().Write("A1").Write("B1")
+                    .SkipRows(2);
 
-    [Test]
-    public static void UnderLine()
-    {
-        using var stream = new MemoryStream();
-        using (var xlsxWriter = new XlsxWriter(stream))
-        {
-            var singleUnderLineStyle =
-                XlsxStyle.Default.With(XlsxFont.Default.WithUnderline());
-            var doubleUnderLineStyle =
-                XlsxStyle.Default.With(XlsxFont.Default.WithUnderline(XlsxFont.Underline.Double));
-
-            xlsxWriter.BeginWorksheet("Sheet1")
-                .BeginRow().Write("Row1")
-                .BeginRow().Write("Row2", singleUnderLineStyle)
-                .BeginRow().Write("Row3", doubleUnderLineStyle);
+            xlsxWriter.CurrentRowNumber.ShouldBe(3);
+            xlsxWriter.CurrentColumnNumber.ShouldBe(0);
+            }
         }
 
-        using var package = new ExcelPackage(stream);
-        var sheet = package.Workbook.Worksheets[0];
-
-        sheet.Cells["A1"].Style.Font.UnderLine.ShouldBe(false);
-        sheet.Cells["A1"].Style.Font.UnderLineType.ShouldBe(ExcelUnderLineType.None);
-        sheet.Cells["A2"].Style.Font.UnderLine.ShouldBe(true);
-        sheet.Cells["A2"].Style.Font.UnderLineType.ShouldBe(ExcelUnderLineType.Single);
-        sheet.Cells["A3"].Style.Font.UnderLine.ShouldBe(true);
-        sheet.Cells["A3"].Style.Font.UnderLineType.ShouldBe(ExcelUnderLineType.Double);
-    }
-
-    [Test]
-    public static void MultipleSheets()
-    {
-        using var stream = new MemoryStream();
-        using (var xlsxWriter = new XlsxWriter(stream))
+        [Test]
+        public static void InsertionPointAfterMergedCells()
         {
-            xlsxWriter
-                .BeginWorksheet("Sheet1")
-                .BeginRow().Write("Sheet1.A1").Write("Sheet1.B1").Write("Sheet1.C1")
-                .BeginRow().Write("Sheet1.A2", columnSpan: 2).Write("Sheet1.C2")
-                .BeginWorksheet("Sheet2")
-                .BeginRow().AddMergedCell(1, 2).Write("Sheet2.A1").SkipColumns(1).Write("Sheet2.C1")
-                .BeginRow().Write("Sheet2.A2").Write("Sheet2.B2").Write("Sheet2.C2");
+            using (var stream = new MemoryStream())
+            using (var xlsxWriter = new XlsxWriter(stream))
+            {
+                xlsxWriter.BeginWorksheet("Sheet1")
+                    .BeginRow().Write("A1").Write("B1", columnSpan: 3);
+
+                xlsxWriter.CurrentRowNumber.ShouldBe(1);
+                xlsxWriter.CurrentColumnNumber.ShouldBe(5);
+            }
         }
 
-        using var package = new ExcelPackage(stream);
-        package.Workbook.Worksheets.Count.ShouldBe(2);
-
-        var sheet1 = package.Workbook.Worksheets[0];
-        sheet1.Name.ShouldBe("Sheet1");
-        sheet1.Cells["A1"].Value.ShouldBe("Sheet1.A1");
-        sheet1.Cells["B1"].Value.ShouldBe("Sheet1.B1");
-        sheet1.Cells["C1"].Value.ShouldBe("Sheet1.C1");
-        sheet1.Cells["A2"].Value.ShouldBe("Sheet1.A2");
-        sheet1.Cells["B2"].Value.ShouldBeNull();
-        sheet1.Cells["C2"].Value.ShouldBe("Sheet1.C2");
-        sheet1.Cells["A2:B2"].Merge.ShouldBeTrue();
-
-        var sheet2 = package.Workbook.Worksheets[1];
-        sheet2.Name.ShouldBe("Sheet2");
-        sheet2.Cells["A1"].Value.ShouldBe("Sheet2.A1");
-        sheet2.Cells["B1"].Value.ShouldBeNull();
-        sheet2.Cells["C1"].Value.ShouldBe("Sheet2.C1");
-        sheet2.Cells["A2"].Value.ShouldBe("Sheet2.A2");
-        sheet2.Cells["B2"].Value.ShouldBe("Sheet2.B2");
-        sheet2.Cells["C2"].Value.ShouldBe("Sheet2.C2");
-        sheet2.Cells["A1:B1"].Merge.ShouldBeTrue();
-    }
-
-    [Test]
-    public static void SplitPanesOnMultipleSheets()
-    {
-        using var stream = new MemoryStream();
-        using (var xlsxWriter = new XlsxWriter(stream))
+        [Test]
+        public static void Write()
         {
-            xlsxWriter
-                .BeginWorksheet("Sheet1", splitRow: 1, splitColumn: 2)
-                .BeginWorksheet("Sheet2", splitRow: 2, splitColumn: 1)
-                .BeginWorksheet("OnlyRows", splitRow: 1)
-                .BeginWorksheet("OnlyCols", splitColumn: 1);
+            using (var stream = new MemoryStream())
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                {
+                    xlsxWriter
+                        .BeginWorksheet("Sheet1")
+                        .BeginRow()
+                        .Write("A string")
+                        .Write(123)
+                        .Write(456.0)
+                        .Write(789m)
+                        .Write(new DateTime(2020, 5, 6, 18, 27, 0),
+                            XlsxStyle.Default.With(XlsxNumberFormat.ShortDateTime))
+                        .Write(true)
+                        .Write();
+                }
+
+                using (var package = new ExcelPackage(stream))
+                {
+                    package.Workbook.Worksheets.Count.ShouldBe(1);
+                    var sheet = package.Workbook.Worksheets[0];
+                    sheet.Cells["A1"].Value.ShouldBe("A string");
+                    sheet.Cells["B1"].Value.ShouldBe(123.0);
+                    sheet.Cells["C1"].Value.ShouldBe(456.0);
+                    sheet.Cells["D1"].Value.ShouldBe(789.0);
+                    sheet.Cells["E1"].Value.ShouldBe(new DateTime(2020, 5, 6, 18, 27, 0));
+                    sheet.Cells["F1"].Value.ShouldBe(true);
+                    sheet.Cells["G1"].Value.ShouldBeNull();
+                }
+            }
         }
 
-        using var package = new ExcelPackage(stream);
-        package.Workbook.Worksheets[0].View.ActiveCell.ShouldBe("C2");
-        package.Workbook.Worksheets[1].View.ActiveCell.ShouldBe("B3");
-        package.Workbook.Worksheets[2].View.ActiveCell.ShouldBe("A2");
-        package.Workbook.Worksheets[3].View.ActiveCell.ShouldBe("B1");
-    }
-
-    [Test]
-    public static void AutoFilter()
-    {
-        using var stream = new MemoryStream();
-        using (var xlsxWriter = new XlsxWriter(stream))
-            xlsxWriter
-                .BeginWorksheet("Sheet 1")
-                .BeginRow().Write("A1").Write("B1").Write("C1")
-                .BeginRow().Write("A2").Write("B2").Write("C2")
-                .BeginRow().Write("A3").Write("B3").Write("C3")
-                .BeginRow().Write("A4").Write("B4").Write("C4")
-                .SetAutoFilter(1, 1, xlsxWriter.CurrentRowNumber, 3);
-
-        using var package = new ExcelPackage(stream);
-        package.Workbook.Worksheets[0].AutoFilterAddress.Address.ShouldBe("A1:C4");
-    }
-
-    [Test]
-    public static void WorksheetNameTooLong()
-    {
-        using var stream = new MemoryStream();
-        using var xlsxWriter = new XlsxWriter(stream);
-        Should.Throw<ArgumentException>(() => xlsxWriter.BeginWorksheet("A very, very, very, long worksheet name exceeding what Excel can handle"));
-    }
-
-    [Test]
-    public static void DuplicateWorksheetName()
-    {
-        using var stream = new MemoryStream();
-        using var xlsxWriter = new XlsxWriter(stream);
-        xlsxWriter.BeginWorksheet("Sheet1");
-        Should.Throw<ArgumentException>(() => xlsxWriter.BeginWorksheet("Sheet1"));
-    }
-
-    [Theory]
-    public static void RightToLeftWorksheet(bool rightToLeft)
-    {
-        using var stream = new MemoryStream();
-        using (var xlsxWriter = new XlsxWriter(stream))
-            xlsxWriter
-                .BeginWorksheet("Sheet 1", rightToLeft: rightToLeft)
-                .BeginRow().Write(@"ما هو ""لوريم إيبسوم"" ؟")
-                .BeginRow().Write(@"لوريم إيبسوم(Lorem Ipsum) هو ببساطة نص شكلي (بمعنى أن الغاية هي الشكل وليس المحتوى) ويُستخدم في صناعات المطابع ودور النشر.");
-
-        using var package = new ExcelPackage(stream);
-        package.Workbook.Worksheets[0].View.RightToLeft.ShouldBe(rightToLeft);
-    }
-
-    [Theory]
-    public static void ShowGridlinesWorksheet(bool showGridLines)
-    {
-        using var stream = new MemoryStream();
-        using (var xlsxWriter = new XlsxWriter(stream))
-            xlsxWriter
-                .BeginWorksheet("Sheet 1", showGridLines: showGridLines)
-                .BeginRow().Write("Gridlines are hidden in this sheet.");
-
-        using var package = new ExcelPackage(stream);
-        package.Workbook.Worksheets[0].View.ShowGridLines.ShouldBe(showGridLines);
-    }
-
-    [Theory]
-    public static void ShowHeadersWorksheet(bool showHeaders)
-    {
-        using var stream = new MemoryStream();
-        using (var xlsxWriter = new XlsxWriter(stream))
-            xlsxWriter
-                .BeginWorksheet("Sheet 1", showHeaders: showHeaders)
-                .BeginRow().Write("Row and column headers are hidden in this sheet.");
-
-        using var package = new ExcelPackage(stream);
-        package.Workbook.Worksheets[0].View.ShowHeaders.ShouldBe(showHeaders);
-    }
-
-    [TestCase(XlsxWorksheetState.Visible, eWorkSheetHidden.Visible)]
-    [TestCase(XlsxWorksheetState.Hidden, eWorkSheetHidden.Hidden)]
-    [TestCase(XlsxWorksheetState.VeryHidden, eWorkSheetHidden.VeryHidden)]
-    public static void WorksheetVisibility(XlsxWorksheetState state, eWorkSheetHidden expected)
-    {
-        using var stream = new MemoryStream();
-        using (var xlsxWriter = new XlsxWriter(stream))
-            xlsxWriter.BeginWorksheet("Sheet 1", state: state).BeginRow().Write("A1");
-
-        using var package = new ExcelPackage(stream);
-        package.Workbook.Worksheets[0].Hidden.ShouldBe(expected);
-    }
-
-    [Theory]
-    public static void Zip64(bool useZip64)
-    {
-        using var stream = new MemoryStream();
-        using (var xlsxWriter = new XlsxWriter(stream, useZip64: useZip64))
+        [Test]
+        public static void Simple()
         {
-            xlsxWriter
-                .BeginWorksheet("Sheet1")
-                .BeginRow().Write("A1").Write("B1")
-                .BeginRow().Write("A2").Write("B2");
+            using (var stream = new MemoryStream())
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                {
+                    var whiteFont = new XlsxFont("Segoe UI", 9, System.Drawing.Color.White, bold: true);
+                    var blueFill = new XlsxFill(System.Drawing.Color.FromArgb(0, 0x45, 0x86));
+                    var yellowFill = new XlsxFill(System.Drawing.Color.FromArgb(0xff, 0xff, 0x88));
+                    var headerStyle = new XlsxStyle(whiteFont, blueFill, XlsxBorder.None, XlsxNumberFormat.General,
+                        XlsxAlignment.Default);
+                    var highlightStyle = XlsxStyle.Default.With(yellowFill);
+                    var dateStyle = XlsxStyle.Default.With(XlsxNumberFormat.ShortDateTime);
+
+                    xlsxWriter
+                        .BeginWorksheet("Sheet&'<1>\"")
+                        .SetDefaultStyle(headerStyle)
+                        .BeginRow().Write("Col<1>").Write("Col2").Write("Col&3")
+                        .BeginRow().Write().Write("Sub2").Write("Sub3")
+                        .SetDefaultStyle(XlsxStyle.Default)
+                        .BeginRow().Write("Row3").Write(42).Write(-1, highlightStyle)
+                        .BeginRow().Write("Row4").SkipColumns(1).Write(new DateTime(2020, 5, 6, 18, 27, 0), dateStyle)
+                        .SkipRows(2)
+                        .BeginRow().Write("Row7", columnSpan: 2).Write(3.14159265359)
+                        .BeginRow().Write("Row8").Write(false).Write(true);
+                }
+
+                using (var package = new ExcelPackage(stream))
+                {
+                    package.Workbook.Worksheets.Count.ShouldBe(1);
+                    var sheet = package.Workbook.Worksheets[0];
+                    sheet.Name.ShouldBe("Sheet&'<1>\"");
+
+                    sheet.Cells["A1"].Value.ShouldBe("Col<1>");
+                    sheet.Cells["B1"].Value.ShouldBe("Col2");
+                    sheet.Cells["C1"].Value.ShouldBe("Col&3");
+                    sheet.Cells["A2"].Value.ShouldBeNull();
+                    sheet.Cells["B2"].Value.ShouldBe("Sub2");
+                    sheet.Cells["C2"].Value.ShouldBe("Sub3");
+                    sheet.Cells["A3"].Value.ShouldBe("Row3");
+                    sheet.Cells["B3"].Value.ShouldBe(42);
+                    sheet.Cells["C3"].Value.ShouldBe(-1);
+                    sheet.Cells["A4"].Value.ShouldBe("Row4");
+                    sheet.Cells["B4"].Value.ShouldBeNull();
+                    sheet.Cells["C4"].Value.ShouldBe(new DateTime(2020, 5, 6, 18, 27, 0));
+                    sheet.Cells["C4"].Style.Numberformat.NumFmtID.ShouldBe(22);
+                    sheet.Cells["A5"].Value.ShouldBeNull();
+                    sheet.Cells["A6"].Value.ShouldBeNull();
+                    sheet.Cells["A7"].Value.ShouldBe("Row7");
+                    sheet.Cells["B7"].Value.ShouldBeNull();
+                    sheet.Cells["C7"].Value.ShouldBe(3.14159265359);
+                    sheet.Cells["A8"].Value.ShouldBe("Row8");
+                    sheet.Cells["B8"].Value.ShouldBe(false);
+                    sheet.Cells["C8"].Value.ShouldBe(true);
+
+                    sheet.Cells["A7:B7"].Merge.ShouldBeTrue();
+
+                    foreach (var cell in new[] {"A1", "B1", "C1", "A2", "B2", "C2"})
+                    {
+                        sheet.Cells[cell].Style.Fill.PatternType.ShouldBe(ExcelFillStyle.Solid);
+                        sheet.Cells[cell].Style.Fill.BackgroundColor.Rgb.ShouldBe("FF004586");
+                        sheet.Cells[cell].Style.Font.Bold.ShouldBeTrue();
+                        sheet.Cells[cell].Style.Font.Color.Rgb.ShouldBe("FFFFFFFF");
+                        sheet.Cells[cell].Style.Font.Name.ShouldBe("Segoe UI");
+                        sheet.Cells[cell].Style.Font.Size.ShouldBe(9);
+                    }
+
+                    sheet.Cells["C3"].Style.Fill.PatternType.ShouldBe(ExcelFillStyle.Solid);
+                    sheet.Cells["C3"].Style.Fill.BackgroundColor.Rgb.ShouldBe("FFFFFF88");
+                    sheet.Cells["C3"].Style.Font.Bold.ShouldBeFalse();
+                    sheet.Cells["C3"].Style.Font.Color.Rgb.ShouldBe("FF000000");
+                    sheet.Cells["C3"].Style.Font.Name.ShouldBe("Calibri");
+                    sheet.Cells["C3"].Style.Font.Size.ShouldBe(11);
+
+                    foreach (var cell in new[]
+                                 {"A3", "B3", "A4", "B4", "C4", "A5", "B5", "C5", "A6", "B6", "C6", "A7", "B7", "C7"})
+                    {
+                        sheet.Cells[cell].Style.Fill.PatternType.ShouldBe(ExcelFillStyle.None);
+                        sheet.Cells[cell].Style.Font.Bold.ShouldBeFalse();
+                        sheet.Cells[cell].Style.Font.Color.Rgb.ShouldBe("FF000000");
+                        sheet.Cells[cell].Style.Font.Name.ShouldBe("Calibri");
+                        sheet.Cells[cell].Style.Font.Size.ShouldBe(11);
+                    }
+                }
+            }
         }
 
-        using var package = new ExcelPackage(stream);
-        package.Workbook.Worksheets.Count.ShouldBe(1);
-        var sheet = package.Workbook.Worksheets[0];
-        sheet.Name.ShouldBe("Sheet1");
-        sheet.Cells["A1"].Value.ShouldBe("A1");
-        sheet.Cells["B1"].Value.ShouldBe("B1");
-        sheet.Cells["A2"].Value.ShouldBe("A2");
-        sheet.Cells["B2"].Value.ShouldBe("B2");
-    }
-
-    [Test]
-    public static void SheetProtection()
-    {
-        using var stream = new MemoryStream();
-        using (var xlsxWriter = new XlsxWriter(stream))
+        [Test]
+        public static void UnderLine()
         {
-            xlsxWriter
-                .BeginWorksheet("Sheet1")
-                .SetSheetProtection(new XlsxSheetProtection("Lorem ipsum", autoFilter: false))
-                .BeginRow().Write("A1");
+            using (var stream = new MemoryStream())
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                {
+                    var singleUnderLineStyle =
+                        XlsxStyle.Default.With(XlsxFont.Default.WithUnderline());
+                    var doubleUnderLineStyle =
+                        XlsxStyle.Default.With(XlsxFont.Default.WithUnderline(XlsxFont.Underline.Double));
+
+                    xlsxWriter.BeginWorksheet("Sheet1")
+                        .BeginRow().Write("Row1")
+                        .BeginRow().Write("Row2", singleUnderLineStyle)
+                        .BeginRow().Write("Row3", doubleUnderLineStyle);
+                }
+
+                using (var package = new ExcelPackage(stream))
+                {
+                    var sheet = package.Workbook.Worksheets[0];
+
+                    sheet.Cells["A1"].Style.Font.UnderLine.ShouldBe(false);
+                    sheet.Cells["A1"].Style.Font.UnderLineType.ShouldBe(ExcelUnderLineType.None);
+                    sheet.Cells["A2"].Style.Font.UnderLine.ShouldBe(true);
+                    sheet.Cells["A2"].Style.Font.UnderLineType.ShouldBe(ExcelUnderLineType.Single);
+                    sheet.Cells["A3"].Style.Font.UnderLine.ShouldBe(true);
+                    sheet.Cells["A3"].Style.Font.UnderLineType.ShouldBe(ExcelUnderLineType.Double);
+                }
+            }
         }
 
-        using var package = new ExcelPackage(stream);
-        package.Workbook.Worksheets.Count.ShouldBe(1);
-        var protection = package.Workbook.Worksheets[0].Protection;
-        protection.IsProtected.ShouldBeTrue();
-        protection.AllowAutoFilter.ShouldBeTrue();
-        protection.AllowDeleteColumns.ShouldBeFalse();
-        protection.AllowDeleteRows.ShouldBeFalse();
-        protection.AllowEditObject.ShouldBeFalse();
-        protection.AllowEditScenarios.ShouldBeFalse();
-        protection.AllowFormatCells.ShouldBeFalse();
-        protection.AllowFormatColumns.ShouldBeFalse();
-        protection.AllowFormatRows.ShouldBeFalse();
-        protection.AllowInsertColumns.ShouldBeFalse();
-        protection.AllowInsertHyperlinks.ShouldBeFalse();
-        protection.AllowInsertRows.ShouldBeFalse();
-        protection.AllowPivotTables.ShouldBeFalse();
-        protection.AllowSelectLockedCells.ShouldBeTrue();
-        protection.AllowSelectUnlockedCells.ShouldBeTrue();
-        protection.AllowSort.ShouldBeFalse();
-    }
-
-    [Test]
-    public static void SheetProtection_PasswordTooShort()
-    {
-        using var stream = new MemoryStream();
-        using var xlsxWriter = new XlsxWriter(stream);
-        Should.Throw<ArgumentException>(() => xlsxWriter.BeginWorksheet("Sheet1").SetSheetProtection(new XlsxSheetProtection("")));
-    }
-
-    [Test]
-    public static void SheetProtection_PasswordTooLong()
-    {
-        using var stream = new MemoryStream();
-        using var xlsxWriter = new XlsxWriter(stream);
-        Should.Throw<ArgumentException>(() => xlsxWriter.BeginWorksheet("Sheet1").SetSheetProtection(new XlsxSheetProtection("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in")));
-    }
-
-    [Test]
-    public static void SharedStrings()
-    {
-        using var stream = new MemoryStream();
-        using (var xlsxWriter = new XlsxWriter(stream))
+        [Test]
+        public static void MultipleSheets()
         {
-            xlsxWriter
-                .BeginWorksheet("Sheet1")
-                .BeginRow().Write("Lorem ipsum dolor sit amet")
-                .BeginRow().WriteSharedString("Lorem ipsum dolor sit amet")
-                .BeginRow().WriteSharedString("Lorem ipsum dolor sit amet")
-                .BeginRow().WriteSharedString("consectetur adipiscing elit")
-                .BeginRow().WriteSharedString("consectetur adipiscing elit")
-                .BeginRow().WriteSharedString("Lorem ipsum dolor sit amet");
+            using (var stream = new MemoryStream())
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                {
+                    xlsxWriter
+                        .BeginWorksheet("Sheet1")
+                        .BeginRow().Write("Sheet1.A1").Write("Sheet1.B1").Write("Sheet1.C1")
+                        .BeginRow().Write("Sheet1.A2", columnSpan: 2).Write("Sheet1.C2")
+                        .BeginWorksheet("Sheet2")
+                        .BeginRow().AddMergedCell(1, 2).Write("Sheet2.A1").SkipColumns(1).Write("Sheet2.C1")
+                        .BeginRow().Write("Sheet2.A2").Write("Sheet2.B2").Write("Sheet2.C2");
+                }
+
+                using (var package = new ExcelPackage(stream))
+                {
+                    package.Workbook.Worksheets.Count.ShouldBe(2);
+
+                    var sheet1 = package.Workbook.Worksheets[0];
+                    sheet1.Name.ShouldBe("Sheet1");
+                    sheet1.Cells["A1"].Value.ShouldBe("Sheet1.A1");
+                    sheet1.Cells["B1"].Value.ShouldBe("Sheet1.B1");
+                    sheet1.Cells["C1"].Value.ShouldBe("Sheet1.C1");
+                    sheet1.Cells["A2"].Value.ShouldBe("Sheet1.A2");
+                    sheet1.Cells["B2"].Value.ShouldBeNull();
+                    sheet1.Cells["C2"].Value.ShouldBe("Sheet1.C2");
+                    sheet1.Cells["A2:B2"].Merge.ShouldBeTrue();
+
+                    var sheet2 = package.Workbook.Worksheets[1];
+                    sheet2.Name.ShouldBe("Sheet2");
+                    sheet2.Cells["A1"].Value.ShouldBe("Sheet2.A1");
+                    sheet2.Cells["B1"].Value.ShouldBeNull();
+                    sheet2.Cells["C1"].Value.ShouldBe("Sheet2.C1");
+                    sheet2.Cells["A2"].Value.ShouldBe("Sheet2.A2");
+                    sheet2.Cells["B2"].Value.ShouldBe("Sheet2.B2");
+                    sheet2.Cells["C2"].Value.ShouldBe("Sheet2.C2");
+                    sheet2.Cells["A1:B1"].Merge.ShouldBeTrue();
+                }
+            }
         }
 
-        using var package = new ExcelPackage(stream);
-        package.Workbook.Worksheets.Count.ShouldBe(1);
-        var sheet = package.Workbook.Worksheets[0];
-        sheet.Name.ShouldBe("Sheet1");
-        sheet.Cells["A1"].Value.ShouldBe("Lorem ipsum dolor sit amet");
-        sheet.Cells["A2"].Value.ShouldBe("Lorem ipsum dolor sit amet");
-        sheet.Cells["A3"].Value.ShouldBe("Lorem ipsum dolor sit amet");
-        sheet.Cells["A4"].Value.ShouldBe("consectetur adipiscing elit");
-        sheet.Cells["A5"].Value.ShouldBe("consectetur adipiscing elit");
-        sheet.Cells["A6"].Value.ShouldBe("Lorem ipsum dolor sit amet");
-    }
-
-    [Theory]
-    public static void RequireCellReferences(bool requireCellReferences)
-    {
-        using var stream = new MemoryStream();
-        using (var xlsxWriter = new XlsxWriter(stream, requireCellReferences: requireCellReferences))
+        [Test]
+        public static void SplitPanesOnMultipleSheets()
         {
-            xlsxWriter.BeginWorksheet("Sheet1").BeginRow().Write("Lorem").Write("ipsum");
+            using (var stream = new MemoryStream())
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                {
+                    xlsxWriter
+                        .BeginWorksheet("Sheet1", splitRow: 1, splitColumn: 2)
+                        .BeginWorksheet("Sheet2", splitRow: 2, splitColumn: 1)
+                        .BeginWorksheet("OnlyRows", splitRow: 1)
+                        .BeginWorksheet("OnlyCols", splitColumn: 1);
+                }
+
+                using (var package = new ExcelPackage(stream))
+                {
+                    package.Workbook.Worksheets[0].View.ActiveCell.ShouldBe("C2");
+                    package.Workbook.Worksheets[1].View.ActiveCell.ShouldBe("B3");
+                    package.Workbook.Worksheets[2].View.ActiveCell.ShouldBe("A2");
+                    package.Workbook.Worksheets[3].View.ActiveCell.ShouldBe("B1");
+                }
+            }
         }
 
-        using var spreadsheetDocument = SpreadsheetDocument.Open(stream, false);
-        var sheetId = spreadsheetDocument.WorkbookPart!.Workbook.Sheets!.Elements<Sheet>().Single(s => s.Name == "Sheet1").Id!.ToString()!;
-        var worksheetPart = (WorksheetPart)spreadsheetDocument.WorkbookPart!.GetPartById(sheetId);
-        worksheetPart.Worksheet
-            .Descendants<Row>().Single()
-            .Descendants<Cell>().Any(c => c.CellReference == "B1")
-            .ShouldBe(requireCellReferences);
-    }
-
-    [Test]
-    public static void InvalidXmlCharacters()
-    {
-        using var stream = new MemoryStream();
-        using (var xlsxWriter = new XlsxWriter(stream, skipInvalidCharacters: true))
+        [Test]
+        public static void AutoFilter()
         {
-            xlsxWriter
-                .BeginWorksheet("Sheet\01")
-                .SetHeaderFooter(new XlsxHeaderFooter(
-                    oddHeader: "&COdd h\0eader",
-                    oddFooter: "&COdd f\0ooter",
-                    evenHeader: "&CEven h\0eader",
-                    evenFooter: "&CEven f\0ooter",
-                    firstHeader: "&CFirst he\0ader",
-                    firstFooter: "&CFirst fo\0oter"))
-                .BeginRow().Write("Inline str\0ing")
-                .BeginRow().WriteSharedString("Shared str\0ing")
-                .BeginRow().WriteFormula("=A2&\0A3", result: "Inline stringShared string")
-                .BeginRow().AddDataValidation(
-                    XlsxDataValidation.List(
-                        choices: ["Choice\01", "Choice2"],
-                        showErrorMessage: true, errorTitle: "Error ti\0tle", error: "A very inform\0ative error message",
-                        showInputMessage: true, promptTitle: "Prompt ti\0tle", prompt: "A very enlig\0htening prompt"));
+            using (var stream = new MemoryStream())
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                    xlsxWriter
+                        .BeginWorksheet("Sheet 1")
+                        .BeginRow().Write("A1").Write("B1").Write("C1")
+                        .BeginRow().Write("A2").Write("B2").Write("C2")
+                        .BeginRow().Write("A3").Write("B3").Write("C3")
+                        .BeginRow().Write("A4").Write("B4").Write("C4")
+                        .SetAutoFilter(1, 1, xlsxWriter.CurrentRowNumber, 3);
+
+                using (var package = new ExcelPackage(stream))
+                {
+                    package.Workbook.Worksheets[0].AutoFilterAddress.Address.ShouldBe("A1:C4");
+                }
+            }
         }
 
-        using var package = new ExcelPackage(stream);
-        package.Workbook.Worksheets.Count.ShouldBe(1);
-        var sheet = package.Workbook.Worksheets[0];
-        sheet.Name.ShouldBe("Sheet1");
-        sheet.Cells["A1"].Value.ShouldBe("Inline string");
-        sheet.Cells["A2"].Value.ShouldBe("Shared string");
-        sheet.Cells["A3"].Value.ShouldBe("Inline stringShared string");
-        sheet.HeaderFooter.OddHeader.CenteredText.ShouldBe("Odd header");
-        sheet.HeaderFooter.OddFooter.CenteredText.ShouldBe("Odd footer");
-        sheet.HeaderFooter.EvenHeader.CenteredText.ShouldBe("Even header");
-        sheet.HeaderFooter.EvenFooter.CenteredText.ShouldBe("Even footer");
-        sheet.HeaderFooter.FirstHeader.CenteredText.ShouldBe("First header");
-        sheet.HeaderFooter.FirstFooter.CenteredText.ShouldBe("First footer");
-        var dataValidation = (ExcelDataValidationList)package.Workbook.Worksheets[0].DataValidations[0];
-        dataValidation.ErrorTitle.ShouldBe("Error title");
-        dataValidation.Error.ShouldBe("A very informative error message");
-        dataValidation.PromptTitle.ShouldBe("Prompt title");
-        dataValidation.Prompt.ShouldBe("A very enlightening prompt");
-        dataValidation.Formula.Values.ShouldBe(["Choice1", "Choice2"]);
+        [Test]
+        public static void WorksheetNameTooLong()
+        {
+            using (var stream = new MemoryStream())
+            using (var xlsxWriter = new XlsxWriter(stream))
+                Should.Throw<ArgumentException>(() =>
+                    xlsxWriter.BeginWorksheet("A very, very, very, long worksheet name exceeding what Excel can handle"));
+        }
+
+        [Test]
+        public static void DuplicateWorksheetName()
+        {
+            using (var stream = new MemoryStream())
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                {
+                    xlsxWriter.BeginWorksheet("Sheet1");
+                    Should.Throw<ArgumentException>(() => xlsxWriter.BeginWorksheet("Sheet1"));
+                }
+            }
+        }
+
+        [Theory]
+        public static void RightToLeftWorksheet(bool rightToLeft)
+        {
+            using (var stream = new MemoryStream())
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                    xlsxWriter
+                        .BeginWorksheet("Sheet 1", rightToLeft: rightToLeft)
+                        .BeginRow().Write(@"ما هو ""لوريم إيبسوم"" ؟")
+                        .BeginRow().Write(
+                            @"لوريم إيبسوم(Lorem Ipsum) هو ببساطة نص شكلي (بمعنى أن الغاية هي الشكل وليس المحتوى) ويُستخدم في صناعات المطابع ودور النشر.");
+
+                using (var package = new ExcelPackage(stream))
+                    package.Workbook.Worksheets[0].View.RightToLeft.ShouldBe(rightToLeft);
+            }
+        }
+
+        [Theory]
+        public static void ShowGridlinesWorksheet(bool showGridLines)
+        {
+            using (var stream = new MemoryStream())
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                    xlsxWriter
+                        .BeginWorksheet("Sheet 1", showGridLines: showGridLines)
+                        .BeginRow().Write("Gridlines are hidden in this sheet.");
+
+                using (var package = new ExcelPackage(stream))
+                    package.Workbook.Worksheets[0].View.ShowGridLines.ShouldBe(showGridLines);
+            }
+        }
+
+        [Theory]
+        public static void ShowHeadersWorksheet(bool showHeaders)
+        {
+            using (var stream = new MemoryStream())
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                    xlsxWriter
+                        .BeginWorksheet("Sheet 1", showHeaders: showHeaders)
+                        .BeginRow().Write("Row and column headers are hidden in this sheet.");
+
+                using (var package = new ExcelPackage(stream))
+                    package.Workbook.Worksheets[0].View.ShowHeaders.ShouldBe(showHeaders);
+            }
+        }
+
+        [TestCase(XlsxWorksheetState.Visible, eWorkSheetHidden.Visible)]
+        [TestCase(XlsxWorksheetState.Hidden, eWorkSheetHidden.Hidden)]
+        [TestCase(XlsxWorksheetState.VeryHidden, eWorkSheetHidden.VeryHidden)]
+        public static void WorksheetVisibility(XlsxWorksheetState state, eWorkSheetHidden expected)
+        {
+            using (var stream = new MemoryStream())
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                    xlsxWriter.BeginWorksheet("Sheet 1", state: state).BeginRow().Write("A1");
+
+                using (var package = new ExcelPackage(stream))
+                    package.Workbook.Worksheets[0].Hidden.ShouldBe(expected);
+            }
+        }
+
+        [Theory]
+        public static void Zip64(bool useZip64)
+        {
+            using (var stream = new MemoryStream())
+            {
+                using (var xlsxWriter = new XlsxWriter(stream, useZip64: useZip64))
+                {
+                    xlsxWriter
+                        .BeginWorksheet("Sheet1")
+                        .BeginRow().Write("A1").Write("B1")
+                        .BeginRow().Write("A2").Write("B2");
+                }
+
+                using (var package = new ExcelPackage(stream))
+                {
+                    package.Workbook.Worksheets.Count.ShouldBe(1);
+                    var sheet = package.Workbook.Worksheets[0];
+                    sheet.Name.ShouldBe("Sheet1");
+                    sheet.Cells["A1"].Value.ShouldBe("A1");
+                    sheet.Cells["B1"].Value.ShouldBe("B1");
+                    sheet.Cells["A2"].Value.ShouldBe("A2");
+                    sheet.Cells["B2"].Value.ShouldBe("B2");
+                }
+            }
+        }
+
+        [Test]
+        public static void SheetProtection()
+        {
+            using (var stream = new MemoryStream())
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                {
+                    xlsxWriter
+                        .BeginWorksheet("Sheet1")
+                        .SetSheetProtection(new XlsxSheetProtection("Lorem ipsum", autoFilter: false))
+                        .BeginRow().Write("A1");
+                }
+
+                using (var package = new ExcelPackage(stream))
+                {
+                    package.Workbook.Worksheets.Count.ShouldBe(1);
+                    var protection = package.Workbook.Worksheets[0].Protection;
+                    protection.IsProtected.ShouldBeTrue();
+                    protection.AllowAutoFilter.ShouldBeTrue();
+                    protection.AllowDeleteColumns.ShouldBeFalse();
+                    protection.AllowDeleteRows.ShouldBeFalse();
+                    protection.AllowEditObject.ShouldBeFalse();
+                    protection.AllowEditScenarios.ShouldBeFalse();
+                    protection.AllowFormatCells.ShouldBeFalse();
+                    protection.AllowFormatColumns.ShouldBeFalse();
+                    protection.AllowFormatRows.ShouldBeFalse();
+                    protection.AllowInsertColumns.ShouldBeFalse();
+                    protection.AllowInsertHyperlinks.ShouldBeFalse();
+                    protection.AllowInsertRows.ShouldBeFalse();
+                    protection.AllowPivotTables.ShouldBeFalse();
+                    protection.AllowSelectLockedCells.ShouldBeTrue();
+                    protection.AllowSelectUnlockedCells.ShouldBeTrue();
+                    protection.AllowSort.ShouldBeFalse();
+                }
+            }
+        }
+
+        [Test]
+        public static void SheetProtection_PasswordTooShort()
+        {
+            using (var stream = new MemoryStream())
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                    Should.Throw<ArgumentException>(() =>
+                        xlsxWriter.BeginWorksheet("Sheet1").SetSheetProtection(new XlsxSheetProtection("")));
+            }
+        }
+
+        [Test]
+        public static void SheetProtection_PasswordTooLong()
+        {
+            using (var stream = new MemoryStream())
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                    Should.Throw<ArgumentException>(() => xlsxWriter.BeginWorksheet("Sheet1").SetSheetProtection(
+                        new XlsxSheetProtection(
+                            "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in")));
+            }
+        }
+
+        [Test]
+        public static void SharedStrings()
+        {
+            using (var stream = new MemoryStream())
+            {
+                using (var xlsxWriter = new XlsxWriter(stream))
+                {
+                    xlsxWriter
+                        .BeginWorksheet("Sheet1")
+                        .BeginRow().Write("Lorem ipsum dolor sit amet")
+                        .BeginRow().WriteSharedString("Lorem ipsum dolor sit amet")
+                        .BeginRow().WriteSharedString("Lorem ipsum dolor sit amet")
+                        .BeginRow().WriteSharedString("consectetur adipiscing elit")
+                        .BeginRow().WriteSharedString("consectetur adipiscing elit")
+                        .BeginRow().WriteSharedString("Lorem ipsum dolor sit amet");
+                }
+
+                using (var package = new ExcelPackage(stream))
+                {
+                    package.Workbook.Worksheets.Count.ShouldBe(1);
+                    var sheet = package.Workbook.Worksheets[0];
+                    sheet.Name.ShouldBe("Sheet1");
+                    sheet.Cells["A1"].Value.ShouldBe("Lorem ipsum dolor sit amet");
+                    sheet.Cells["A2"].Value.ShouldBe("Lorem ipsum dolor sit amet");
+                    sheet.Cells["A3"].Value.ShouldBe("Lorem ipsum dolor sit amet");
+                    sheet.Cells["A4"].Value.ShouldBe("consectetur adipiscing elit");
+                    sheet.Cells["A5"].Value.ShouldBe("consectetur adipiscing elit");
+                    sheet.Cells["A6"].Value.ShouldBe("Lorem ipsum dolor sit amet");
+                }
+            }
+        }
+
+        [Theory]
+        public static void RequireCellReferences(bool requireCellReferences)
+        {
+            using (var stream = new MemoryStream())
+            {
+                using (var xlsxWriter = new XlsxWriter(stream, requireCellReferences: requireCellReferences))
+                {
+                    xlsxWriter.BeginWorksheet("Sheet1").BeginRow().Write("Lorem").Write("ipsum");
+                }
+
+                using (var spreadsheetDocument = SpreadsheetDocument.Open(stream, false))
+                {
+                    var sheetId = spreadsheetDocument.WorkbookPart?.Workbook.Sheets?.Elements<Sheet>()
+                        .Single(s => s.Name == "Sheet1").Id?.ToString();
+                    sheetId.ShouldNotBeNull();
+
+                    var worksheetPart = spreadsheetDocument.WorkbookPart?.GetPartById(sheetId) as WorksheetPart;
+                    worksheetPart.ShouldNotBeNull();
+
+                    worksheetPart.Worksheet
+                        .Descendants<Row>().Single()
+                        .Descendants<Cell>().Any(c => c.CellReference == "B1")
+                        .ShouldBe(requireCellReferences);
+                }
+            }
+        }
+    
+
+        [Test]
+        public static void InvalidXmlCharacters()
+        {
+            using (var stream = new MemoryStream())
+            {
+                using (var xlsxWriter = new XlsxWriter(stream, skipInvalidCharacters: true))
+                {
+                    xlsxWriter
+                        .BeginWorksheet("Sheet\01")
+                        .SetHeaderFooter(new XlsxHeaderFooter(
+                            oddHeader: "&COdd h\0eader",
+                            oddFooter: "&COdd f\0ooter",
+                            evenHeader: "&CEven h\0eader",
+                            evenFooter: "&CEven f\0ooter",
+                            firstHeader: "&CFirst he\0ader",
+                            firstFooter: "&CFirst fo\0oter"))
+                        .BeginRow().Write("Inline str\0ing")
+                        .BeginRow().WriteSharedString("Shared str\0ing")
+                        .BeginRow().WriteFormula("=A2&\0A3", result: "Inline stringShared string")
+                        .BeginRow().AddDataValidation(
+                            XlsxDataValidation.List(
+                                choices: new[] {"Choice\01", "Choice2"},
+                                showErrorMessage: true, errorTitle: "Error ti\0tle",
+                                error: "A very inform\0ative error message",
+                                showInputMessage: true, promptTitle: "Prompt ti\0tle",
+                                prompt: "A very enlig\0htening prompt"));
+                }
+
+                using (var package = new ExcelPackage(stream))
+                {
+                    package.Workbook.Worksheets.Count.ShouldBe(1);
+                    var sheet = package.Workbook.Worksheets[0];
+                    sheet.Name.ShouldBe("Sheet1");
+                    sheet.Cells["A1"].Value.ShouldBe("Inline string");
+                    sheet.Cells["A2"].Value.ShouldBe("Shared string");
+                    sheet.Cells["A3"].Value.ShouldBe("Inline stringShared string");
+                    sheet.HeaderFooter.OddHeader.CenteredText.ShouldBe("Odd header");
+                    sheet.HeaderFooter.OddFooter.CenteredText.ShouldBe("Odd footer");
+                    sheet.HeaderFooter.EvenHeader.CenteredText.ShouldBe("Even header");
+                    sheet.HeaderFooter.EvenFooter.CenteredText.ShouldBe("Even footer");
+                    sheet.HeaderFooter.FirstHeader.CenteredText.ShouldBe("First header");
+                    sheet.HeaderFooter.FirstFooter.CenteredText.ShouldBe("First footer");
+                    var dataValidation = (ExcelDataValidationList) package.Workbook.Worksheets[0].DataValidations[0];
+                    dataValidation.ErrorTitle.ShouldBe("Error title");
+                    dataValidation.Error.ShouldBe("A very informative error message");
+                    dataValidation.PromptTitle.ShouldBe("Prompt title");
+                    dataValidation.Prompt.ShouldBe("A very enlightening prompt");
+                    dataValidation.Formula.Values.ShouldBe(new[] {"Choice1", "Choice2"});
+                }
+            }
+        }
     }
 }

--- a/LargeXlsx.Tests/XlsxWriterTest.cs
+++ b/LargeXlsx.Tests/XlsxWriterTest.cs
@@ -135,7 +135,9 @@ namespace LargeXlsx.Tests
                 using (var package = new ExcelPackage(stream))
                 {
                     package.Workbook.Worksheets.Count.ShouldBe(1);
-                    var sheet = package.Workbook.Worksheets[0];
+
+                    var worksheetIndex = package.Compatibility.IsWorksheets1Based ? 1 : 0;
+                    var sheet = package.Workbook.Worksheets[worksheetIndex];
                     sheet.Cells["A1"].Value.ShouldBe("A string");
                     sheet.Cells["B1"].Value.ShouldBe(123.0);
                     sheet.Cells["C1"].Value.ShouldBe(456.0);
@@ -178,7 +180,8 @@ namespace LargeXlsx.Tests
                 using (var package = new ExcelPackage(stream))
                 {
                     package.Workbook.Worksheets.Count.ShouldBe(1);
-                    var sheet = package.Workbook.Worksheets[0];
+                    var worksheetIndex = package.Compatibility.IsWorksheets1Based ? 1 : 0;
+                    var sheet = package.Workbook.Worksheets[worksheetIndex];
                     sheet.Name.ShouldBe("Sheet&'<1>\"");
 
                     sheet.Cells["A1"].Value.ShouldBe("Col<1>");
@@ -255,7 +258,8 @@ namespace LargeXlsx.Tests
 
                 using (var package = new ExcelPackage(stream))
                 {
-                    var sheet = package.Workbook.Worksheets[0];
+                    var worksheetIndex = package.Compatibility.IsWorksheets1Based ? 1 : 0;
+                    var sheet = package.Workbook.Worksheets[worksheetIndex];
 
                     sheet.Cells["A1"].Style.Font.UnderLine.ShouldBe(false);
                     sheet.Cells["A1"].Style.Font.UnderLineType.ShouldBe(ExcelUnderLineType.None);
@@ -287,7 +291,8 @@ namespace LargeXlsx.Tests
                 {
                     package.Workbook.Worksheets.Count.ShouldBe(2);
 
-                    var sheet1 = package.Workbook.Worksheets[0];
+                    var worksheetIndex = package.Compatibility.IsWorksheets1Based ? 1 : 0;
+                    var sheet1 = package.Workbook.Worksheets[worksheetIndex];
                     sheet1.Name.ShouldBe("Sheet1");
                     sheet1.Cells["A1"].Value.ShouldBe("Sheet1.A1");
                     sheet1.Cells["B1"].Value.ShouldBe("Sheet1.B1");
@@ -297,7 +302,7 @@ namespace LargeXlsx.Tests
                     sheet1.Cells["C2"].Value.ShouldBe("Sheet1.C2");
                     sheet1.Cells["A2:B2"].Merge.ShouldBeTrue();
 
-                    var sheet2 = package.Workbook.Worksheets[1];
+                    var sheet2 = package.Workbook.Worksheets[worksheetIndex + 1];
                     sheet2.Name.ShouldBe("Sheet2");
                     sheet2.Cells["A1"].Value.ShouldBe("Sheet2.A1");
                     sheet2.Cells["B1"].Value.ShouldBeNull();
@@ -326,10 +331,11 @@ namespace LargeXlsx.Tests
 
                 using (var package = new ExcelPackage(stream))
                 {
-                    package.Workbook.Worksheets[0].View.ActiveCell.ShouldBe("C2");
-                    package.Workbook.Worksheets[1].View.ActiveCell.ShouldBe("B3");
-                    package.Workbook.Worksheets[2].View.ActiveCell.ShouldBe("A2");
-                    package.Workbook.Worksheets[3].View.ActiveCell.ShouldBe("B1");
+                    var worksheetIndex = package.Compatibility.IsWorksheets1Based ? 1 : 0;
+                    package.Workbook.Worksheets[worksheetIndex].View.ActiveCell.ShouldBe("C2");
+                    package.Workbook.Worksheets[worksheetIndex+1].View.ActiveCell.ShouldBe("B3");
+                    package.Workbook.Worksheets[worksheetIndex+2].View.ActiveCell.ShouldBe("A2");
+                    package.Workbook.Worksheets[worksheetIndex+3].View.ActiveCell.ShouldBe("B1");
                 }
             }
         }
@@ -350,7 +356,8 @@ namespace LargeXlsx.Tests
 
                 using (var package = new ExcelPackage(stream))
                 {
-                    package.Workbook.Worksheets[0].AutoFilterAddress.Address.ShouldBe("A1:C4");
+                    var worksheetIndex = package.Compatibility.IsWorksheets1Based ? 1 : 0;
+                    package.Workbook.Worksheets[worksheetIndex].AutoFilterAddress.Address.ShouldBe("A1:C4");
                 }
             }
         }
@@ -390,7 +397,10 @@ namespace LargeXlsx.Tests
                             @"لوريم إيبسوم(Lorem Ipsum) هو ببساطة نص شكلي (بمعنى أن الغاية هي الشكل وليس المحتوى) ويُستخدم في صناعات المطابع ودور النشر.");
 
                 using (var package = new ExcelPackage(stream))
-                    package.Workbook.Worksheets[0].View.RightToLeft.ShouldBe(rightToLeft);
+                {
+                    var worksheetIndex = package.Compatibility.IsWorksheets1Based ? 1 : 0;
+                    package.Workbook.Worksheets[worksheetIndex].View.RightToLeft.ShouldBe(rightToLeft);
+                }
             }
         }
 
@@ -405,7 +415,10 @@ namespace LargeXlsx.Tests
                         .BeginRow().Write("Gridlines are hidden in this sheet.");
 
                 using (var package = new ExcelPackage(stream))
-                    package.Workbook.Worksheets[0].View.ShowGridLines.ShouldBe(showGridLines);
+                {
+                    var worksheetIndex = package.Compatibility.IsWorksheets1Based ? 1 : 0;
+                    package.Workbook.Worksheets[worksheetIndex].View.ShowGridLines.ShouldBe(showGridLines);
+                }
             }
         }
 
@@ -420,7 +433,10 @@ namespace LargeXlsx.Tests
                         .BeginRow().Write("Row and column headers are hidden in this sheet.");
 
                 using (var package = new ExcelPackage(stream))
-                    package.Workbook.Worksheets[0].View.ShowHeaders.ShouldBe(showHeaders);
+                {
+                    var worksheetIndex = package.Compatibility.IsWorksheets1Based ? 1 : 0;
+                    package.Workbook.Worksheets[worksheetIndex].View.ShowHeaders.ShouldBe(showHeaders);
+                }
             }
         }
 
@@ -435,7 +451,10 @@ namespace LargeXlsx.Tests
                     xlsxWriter.BeginWorksheet("Sheet 1", state: state).BeginRow().Write("A1");
 
                 using (var package = new ExcelPackage(stream))
-                    package.Workbook.Worksheets[0].Hidden.ShouldBe(expected);
+                {
+                    var worksheetIndex = package.Compatibility.IsWorksheets1Based ? 1 : 0;
+                    package.Workbook.Worksheets[worksheetIndex].Hidden.ShouldBe(expected);
+                }
             }
         }
 
@@ -455,7 +474,8 @@ namespace LargeXlsx.Tests
                 using (var package = new ExcelPackage(stream))
                 {
                     package.Workbook.Worksheets.Count.ShouldBe(1);
-                    var sheet = package.Workbook.Worksheets[0];
+                    var worksheetIndex = package.Compatibility.IsWorksheets1Based ? 1 : 0;
+                    var sheet = package.Workbook.Worksheets[worksheetIndex];
                     sheet.Name.ShouldBe("Sheet1");
                     sheet.Cells["A1"].Value.ShouldBe("A1");
                     sheet.Cells["B1"].Value.ShouldBe("B1");
@@ -481,7 +501,8 @@ namespace LargeXlsx.Tests
                 using (var package = new ExcelPackage(stream))
                 {
                     package.Workbook.Worksheets.Count.ShouldBe(1);
-                    var protection = package.Workbook.Worksheets[0].Protection;
+                    var worksheetIndex = package.Compatibility.IsWorksheets1Based ? 1 : 0;
+                    var protection = package.Workbook.Worksheets[worksheetIndex].Protection;
                     protection.IsProtected.ShouldBeTrue();
                     protection.AllowAutoFilter.ShouldBeTrue();
                     protection.AllowDeleteColumns.ShouldBeFalse();
@@ -545,7 +566,8 @@ namespace LargeXlsx.Tests
                 using (var package = new ExcelPackage(stream))
                 {
                     package.Workbook.Worksheets.Count.ShouldBe(1);
-                    var sheet = package.Workbook.Worksheets[0];
+                    var worksheetIndex = package.Compatibility.IsWorksheets1Based ? 1 : 0;
+                    var sheet = package.Workbook.Worksheets[worksheetIndex];
                     sheet.Name.ShouldBe("Sheet1");
                     sheet.Cells["A1"].Value.ShouldBe("Lorem ipsum dolor sit amet");
                     sheet.Cells["A2"].Value.ShouldBe("Lorem ipsum dolor sit amet");
@@ -616,7 +638,8 @@ namespace LargeXlsx.Tests
                 using (var package = new ExcelPackage(stream))
                 {
                     package.Workbook.Worksheets.Count.ShouldBe(1);
-                    var sheet = package.Workbook.Worksheets[0];
+                    var worksheetIndex = package.Compatibility.IsWorksheets1Based ? 1 : 0;
+                    var sheet = package.Workbook.Worksheets[worksheetIndex];
                     sheet.Name.ShouldBe("Sheet1");
                     sheet.Cells["A1"].Value.ShouldBe("Inline string");
                     sheet.Cells["A2"].Value.ShouldBe("Shared string");
@@ -627,7 +650,7 @@ namespace LargeXlsx.Tests
                     sheet.HeaderFooter.EvenFooter.CenteredText.ShouldBe("Even footer");
                     sheet.HeaderFooter.FirstHeader.CenteredText.ShouldBe("First header");
                     sheet.HeaderFooter.FirstFooter.CenteredText.ShouldBe("First footer");
-                    var dataValidation = (ExcelDataValidationList) package.Workbook.Worksheets[0].DataValidations[0];
+                    var dataValidation = (ExcelDataValidationList) package.Workbook.Worksheets[worksheetIndex].DataValidations[0];
                     dataValidation.ErrorTitle.ShouldBe("Error title");
                     dataValidation.Error.ShouldBe("A very informative error message");
                     dataValidation.PromptTitle.ShouldBe("Prompt title");


### PR DESCRIPTION
Changed unit tests (`XlsxLarge.Tests`) to multi-target net48, net6.0 and net8.0
Changed `Examples` project to multi-target net48, net6.0 and net8.0

Developers who lack one of the frameworks will still be able to load the solution and build, but obviously won't be able to run the unit tests or examples that rely on the missing .NET versions.