### PR TITLE
Add benchmarks for low-level writes

### DIFF
--- a/LargeXlsx.Benchmarks/LargeXlsx.Benchmarks.csproj
+++ b/LargeXlsx.Benchmarks/LargeXlsx.Benchmarks.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\LargeXlsx\LargeXlsx.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/LargeXlsx.Benchmarks/Program.cs
+++ b/LargeXlsx.Benchmarks/Program.cs
@@ -1,0 +1,12 @@
+﻿using BenchmarkDotNet.Running;
+
+namespace LargeXlsx.Benchmarks
+{
+    internal class Program
+    {
+        static void Main(string[] args)
+        {
+            BenchmarkRunner.Run<WriterLowLevelBenchmarks>();
+        }
+    }
+}

--- a/LargeXlsx.Benchmarks/WriterLowLevelBenchmarks.cs
+++ b/LargeXlsx.Benchmarks/WriterLowLevelBenchmarks.cs
@@ -1,0 +1,138 @@
+using BenchmarkDotNet.Attributes;
+
+namespace LargeXlsx.Benchmarks;
+
+[MemoryDiagnoser]
+public class WriterLowLevelBenchmarks
+{
+    private List<string>? _stringValues;
+
+    [Params(1000, 10000)]
+    public int Rows;
+
+    [Params(4, 16)]
+    public int Cols;
+
+    private static MemoryStream CreateMemoryStream()
+    {
+        return new MemoryStream(2 * 1024 * 1024);
+    }
+
+    private static XlsxWriter CreateWriter(MemoryStream memoryStream)
+    {
+        return new XlsxWriter(memoryStream);
+    }
+
+    private static void CreateWorksheet(XlsxWriter writer)
+    {
+        writer.BeginWorksheet("Sheet1");
+    }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _stringValues = new List<string>(Rows * Cols);
+        for (var i = 0; i < Rows * Cols; i++)
+            _stringValues.Add($"Value_{i}");
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+    }
+
+    [Benchmark]
+    public void Write_Int_DefaultStyle()
+    {
+        using var stream = CreateMemoryStream();
+        using var writer = CreateWriter(stream);
+        CreateWorksheet(writer);
+
+        for (var r = 0; r < Rows; r++)
+        {
+            writer.BeginRow();
+            for (var c = 0; c < Cols; c++)
+                writer.Write(r * Cols + c);
+        }
+    }
+
+    [Benchmark]
+    public void Write_Double_DefaultStyle()
+    {
+        using var stream = CreateMemoryStream();
+        using var writer = CreateWriter(stream);
+        CreateWorksheet(writer);
+
+        for (var r = 0; r < Rows; r++)
+        {
+            writer.BeginRow();
+            for (var c = 0; c < Cols; c++)
+                writer.Write(r * Cols + c + 0.5);
+        }
+    }
+
+    [Benchmark]
+    public void Write_String_Inline()
+    {
+        ArgumentNullException.ThrowIfNull(_stringValues);
+
+        using var stream = CreateMemoryStream();
+        using var writer = CreateWriter(stream);
+        CreateWorksheet(writer);
+
+        var idx = 0;
+        for (var r = 0; r < Rows; r++)
+        {
+            writer.BeginRow();
+            for (var c = 0; c < Cols; c++)
+                writer.Write(_stringValues[idx++]);
+        }
+    }
+
+    [Benchmark]
+    public void Write_String_Shared()
+    {
+       ArgumentNullException.ThrowIfNull(_stringValues);
+
+       using var stream = CreateMemoryStream();
+       using var writer = CreateWriter(stream);
+       CreateWorksheet(writer);
+
+        var idx = 0;
+        for (var r = 0; r < Rows; r++)
+        {
+            writer.BeginRow();
+            for (var c = 0; c < Cols; c++)
+                writer.WriteSharedString(_stringValues[idx++]);
+        }
+    }
+
+    [Benchmark]
+    public void Write_Formula_WithResult()
+    {
+        using var stream = CreateMemoryStream();
+        using var writer = CreateWriter(stream);
+        CreateWorksheet(writer);
+
+        for (var r = 0; r < Rows; r++)
+        {
+            writer.BeginRow();
+            for (var c = 0; c < Cols; c++)
+                writer.WriteFormula($"A{r+1}+B{c+1}", result: r + c);
+        }
+    }
+
+    [Benchmark]
+    public void Write_MergedCells_ColumnSpan()
+    {
+        using var stream = CreateMemoryStream();
+        using var writer = CreateWriter(stream);
+        CreateWorksheet(writer);
+
+        for (var r = 0; r < Rows; r++)
+        {
+            writer.BeginRow();
+            writer.Write("Merged", columnSpan: Cols);
+        }
+    }
+}

--- a/LargeXlsx.sln
+++ b/LargeXlsx.sln
@@ -1,13 +1,15 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 17
+VisualStudioVersion = 17.14.36511.14 d17.14
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LargeXlsx", "LargeXlsx\LargeXlsx.csproj", "{308A5F0D-BD89-45C3-A3A3-13A88C95BB3B}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Examples", "Examples\Examples.csproj", "{869D7E79-84C9-4841-BB4E-D09ED41D44EE}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LargeXlsx.Tests", "LargeXlsx.Tests\LargeXlsx.Tests.csproj", "{504AC08D-4236-4475-A379-E498A499ED44}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LargeXlsx.Benchmarks", "LargeXlsx.Benchmarks\LargeXlsx.Benchmarks.csproj", "{66647EA8-35D4-4247-B42F-2D6BA85CC40C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -55,6 +57,18 @@ Global
 		{504AC08D-4236-4475-A379-E498A499ED44}.Release|x64.Build.0 = Release|Any CPU
 		{504AC08D-4236-4475-A379-E498A499ED44}.Release|x86.ActiveCfg = Release|Any CPU
 		{504AC08D-4236-4475-A379-E498A499ED44}.Release|x86.Build.0 = Release|Any CPU
+		{66647EA8-35D4-4247-B42F-2D6BA85CC40C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{66647EA8-35D4-4247-B42F-2D6BA85CC40C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{66647EA8-35D4-4247-B42F-2D6BA85CC40C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{66647EA8-35D4-4247-B42F-2D6BA85CC40C}.Debug|x64.Build.0 = Debug|Any CPU
+		{66647EA8-35D4-4247-B42F-2D6BA85CC40C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{66647EA8-35D4-4247-B42F-2D6BA85CC40C}.Debug|x86.Build.0 = Debug|Any CPU
+		{66647EA8-35D4-4247-B42F-2D6BA85CC40C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{66647EA8-35D4-4247-B42F-2D6BA85CC40C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{66647EA8-35D4-4247-B42F-2D6BA85CC40C}.Release|x64.ActiveCfg = Release|Any CPU
+		{66647EA8-35D4-4247-B42F-2D6BA85CC40C}.Release|x64.Build.0 = Release|Any CPU
+		{66647EA8-35D4-4247-B42F-2D6BA85CC40C}.Release|x86.ActiveCfg = Release|Any CPU
+		{66647EA8-35D4-4247-B42F-2D6BA85CC40C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This PR introduces a new benchmarking project, LargeXlsx.Benchmarks, to measure and analyse the performance of low-level writing methods in the XlsxWriter class. The benchmarks use BenchmarkDotNet and target typical cell writing scenarios, including integers, doubles, strings (inline and shared), formulas, and merged cells.

Benchmarks run with varying row and column counts (Rows: 1000, 10000; Cols: 4, 16) to simulate different data sizes.

**Motivation**

These benchmarks provide a reproducible way to measure the impact of future optimisations and code changes in the XLSX writing logic. They help identify bottlenecks and track performance improvements over time.

**How to Use**

- Run the LargeXlsx.Benchmarks project to execute all benchmarks.
-  Review the generated reports in the BenchmarkDotNet.Artifacts folder for detailed results.
- Use these results as a baseline for future optimizations.