### PR TITLE
Update SharpCompress (0.40.0 -> 0.48.1) to fix vulnerability

### DIFF
--- a/LargeXlsx/LargeXlsx.csproj
+++ b/LargeXlsx/LargeXlsx.csproj
@@ -14,7 +14,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="SharpCompress" Version="0.40.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+		<PackageReference Include="SharpCompress" Version="0.48.1" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
 		<PackageReference Include="System.Memory" Version="4.6.3" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
 		<None Include="../LICENSE.txt" Pack="true" PackagePath="$(PackageLicenseFile)" />
 	</ItemGroup>

--- a/LargeXlsx/SharpCompressZipWriter.cs
+++ b/LargeXlsx/SharpCompressZipWriter.cs
@@ -46,9 +46,9 @@ public class SharpCompressZipWriter : IZipWriter
             XlsxCompressionLevel.Optimal => CompressionLevel.Default,
             _ => throw new ArgumentOutOfRangeException(nameof(compressionLevel), compressionLevel, null)
         };
-        _zipWriter = (ZipWriter)WriterFactory.Open(stream, ArchiveType.Zip, new ZipWriterOptions(CompressionType.Deflate)
+        _zipWriter = (ZipWriter)WriterFactory.OpenWriter(stream, ArchiveType.Zip, new ZipWriterOptions(CompressionType.Deflate)
         {
-            DeflateCompressionLevel = deflateCompressionLevel,
+            CompressionLevel = (int)deflateCompressionLevel,
             UseZip64 = useZip64
         });
     }


### PR DESCRIPTION
SharpCompress 0.40.0 has a known vulnerability: https://github.com/advisories/GHSA-6c8g-7p36-r338. This is fixed in version 0.48.0, so this PR updates SharpCompress to 0.48.1 (the most recent version). SharpCompress changed their WriterFactory API, so this PR also includes changes to use the new way to create a ZipWriter.

I've run all unit tests and they all succeed.